### PR TITLE
Expand websocket modes and offline settings

### DIFF
--- a/docs/websocket-notes.md
+++ b/docs/websocket-notes.md
@@ -1,0 +1,7 @@
+# WebSocket Container Notes
+
+This interface exposes nine narrative modes: **Boon**, **Bane**, **Bone**, **Bonk**, **Honk**, **Boof**, **Lore**, **Focal**, and **Passive**.
+
+Each mode's settings are stored locally in `localStorage` and may be transmitted to a backend when the `Send to Backend` button is pressed. To hook in real-time updates, listen to WebSocket messages of the form `{type: '<mode>-settings', data: {...}}` and update the UI using the `handleWebSocketMessage` method of each handler.
+
+The container uses a `DataManager` abstraction to source data either from static arrays or from a live WebSocket feed. Extend `modeConfig` in `websocket-container.js` to point a mode at a live URL when the backend is available.

--- a/docs/websocket-options-sample.html
+++ b/docs/websocket-options-sample.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>WebSocket Options Panel Sample</title>
+  <link rel="stylesheet" href="../src/stylesheets/interaction/websocket-container.scss">
+</head>
+<body>
+  <div id="main-websocket-container">
+    <spwashi-websocket-container></spwashi-websocket-container>
+  </div>
+</body>
+</html>

--- a/src/js/services/data-manager.js
+++ b/src/js/services/data-manager.js
@@ -1,0 +1,34 @@
+// services/data-manager.js
+
+import { StaticDataSource, LiveDataSource } from './data-sources.js';
+
+export class DataManager {
+  constructor({ mode, strategy = 'static', staticItems = [], wsUrl = '' }) {
+    if (strategy === 'live') {
+      this.source = new LiveDataSource(wsUrl);
+    } else {
+      this.source = new StaticDataSource(staticItems);
+    }
+    this.mode = mode;
+  }
+
+  getAll() {
+    return this.source.fetchAll();
+  }
+
+  getOne(id) {
+    return this.source.fetchOne(id);
+  }
+
+  onUpdate(cb) {
+    if (this.source.subscribeUpdates) {
+      this.source.subscribeUpdates(cb);
+    }
+  }
+
+  offUpdate(cb) {
+    if (this.source.unsubscribeUpdates) {
+      this.source.unsubscribeUpdates(cb);
+    }
+  }
+}

--- a/src/js/services/data-sources.js
+++ b/src/js/services/data-sources.js
@@ -1,0 +1,73 @@
+// services/data-sources.js
+
+/**
+ * A uniform interface for all data sources.
+ * Methods may return a value or a Promise for that value.
+ */
+export class DataSource {
+  /** Fetch all items: may be sync or async */
+  fetchAll() { throw new Error('fetchAll not implemented'); }
+  /** Fetch a single item by ID or index */
+  fetchOne(id) { throw new Error('fetchOne not implemented'); }
+  /** Subscribe to live updates: callback(item) */
+  subscribeUpdates(callback) {}
+  /** Unsubscribe from updates */
+  unsubscribeUpdates(callback) {}
+}
+
+/** Static (hardcoded) Source */
+export class StaticDataSource extends DataSource {
+  constructor(items = []) {
+    super();
+    this.items = items;
+  }
+  fetchAll() {
+    return this.items;
+  }
+  fetchOne(id) {
+    return this.items.find(item => item.id === id);
+  }
+}
+
+/** Live (async/WebSocket) Source */
+export class LiveDataSource extends DataSource {
+  constructor(wsUrl) {
+    super();
+    this.ws = new WebSocket(wsUrl);
+    this.queue = [];
+    this.callbacks = new Set();
+
+    this.ws.onmessage = (event) => {
+      const item = JSON.parse(event.data);
+      this.queue.push(item);
+      this.callbacks.forEach(cb => cb(item));
+    };
+  }
+
+  async fetchAll() {
+    return new Promise((resolve) => {
+      this.ws.onopen = () => {
+        this.ws.send(JSON.stringify({ type: 'get-all' }));
+        this.ws.onmessage = (event) => {
+          const data = JSON.parse(event.data);
+          if (data.type === 'all-items') {
+            resolve(data.items);
+          }
+        };
+      };
+    });
+  }
+
+  fetchOne(id) {
+    // For demo purposes we rely on fetchAll and filter
+    return this.fetchAll().then(items => items.find(item => item.id === id));
+  }
+
+  subscribeUpdates(cb) {
+    this.callbacks.add(cb);
+  }
+
+  unsubscribeUpdates(cb) {
+    this.callbacks.delete(cb);
+  }
+}

--- a/src/stylesheets/interaction/websocket-container.scss
+++ b/src/stylesheets/interaction/websocket-container.scss
@@ -10,3 +10,19 @@
   font-size: 2rem;
   outline: thin solid var(--accent-color-main);
 }
+form.mode-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-size: 1rem;
+}
+form.mode-form h3 {
+  margin: 0 0 0.5rem 0;
+}
+form.mode-form .button-group {
+  display: flex;
+  gap: 0.5rem;
+}
+form.mode-form button {
+  flex: 1 1 auto;
+}


### PR DESCRIPTION
## Summary
- implement DataSource/DataManager abstraction for mode data
- hook `SpwashiWebSocketContainer` to `DataManager`
- update `BoonModeHandler` to fetch and stream data through `DataManager`
- document mode configuration in `websocket-notes.md`
- add focal and passive modes with unified data updates

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_68530476838c832aa3c7925588c62bdc