### PR TITLE
Convert websocket code to data streams

### DIFF
--- a/docs/websocket-notes.md
+++ b/docs/websocket-notes.md
@@ -1,7 +1,7 @@
-# WebSocket Container Notes
+# Stream Container Notes
 
 This interface exposes nine narrative modes: **Boon**, **Bane**, **Bone**, **Bonk**, **Honk**, **Boof**, **Lore**, **Focal**, and **Passive**.
 
-Each mode's settings are stored locally in `localStorage` and may be transmitted to a backend when the `Send to Backend` button is pressed. To hook in real-time updates, listen to WebSocket messages of the form `{type: '<mode>-settings', data: {...}}` and update the UI using the `handleWebSocketMessage` method of each handler.
+Each mode's settings are stored locally in `localStorage` and may be transmitted to a backend when the `Send to Backend` button is pressed. To hook in real-time updates, listen to stream messages of the form `{type: '<mode>-settings', data: {...}}` and update the UI using the `handleStreamMessage` method of each handler.
 
-The container uses a `DataManager` abstraction to source data either from static arrays or from a live WebSocket feed. Extend `modeConfig` in `websocket-container.js` to point a mode at a live URL when the backend is available.
+The container uses a `DataManager` abstraction to source data either from static arrays or from a live WebSocket feed. Extend `modeConfig` in `stream-container.js` to point a mode at a live URL when the backend is available.

--- a/docs/websocket-options-sample.html
+++ b/docs/websocket-options-sample.html
@@ -2,11 +2,11 @@
 <html>
 <head>
   <title>WebSocket Options Panel Sample</title>
-  <link rel="stylesheet" href="../src/stylesheets/interaction/websocket-container.scss">
+  <link rel="stylesheet" href="../src/stylesheets/interaction/stream-container.scss">
 </head>
 <body>
-  <div id="main-websocket-container">
-    <spwashi-websocket-container></spwashi-websocket-container>
+  <div id="main-stream-container">
+    <spwashi-stream-container></spwashi-stream-container>
   </div>
 </body>
 </html>

--- a/src/index.html
+++ b/src/index.html
@@ -15,9 +15,9 @@
 <body data-mode="nothing" data-interface-depth="standard">
 <button id="main-wonder-button">?</button>
 <h1>&lt;concept&gt;</h1>
-<section id="main-websocket-container">
+<section id="main-stream-container">
     <script src="https://unpkg.com/htmx.org@1.9.2"></script>
-    <spwashi-websocket-container></spwashi-websocket-container>
+    <spwashi-stream-container></spwashi-stream-container>
 </section>
 <a id="title-md5"></a>
 <main>

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -8,7 +8,8 @@ import {initParameters} from "./init/parameters/init";
 import {loadParameters} from "./init/parameters/read";
 import {initSite} from "./init/site";
 import {initAnalytics} from "./meta/analytics";
-import {initWebSocketContainer} from "./ui/websocket-container";
+import {initStreamContainer} from "./ui/stream-container";
+import {initStreamConfig} from "./ui/stream-config";
 
 const versions = {
   'v0.0.1': {
@@ -54,7 +55,8 @@ export async function app() {
 
   // progressive enhancement
   initUi(window.spwashi.initialMode);
-  initWebSocketContainer();
+  initStreamContainer();
+  initStreamConfig();
 
   return Promise.all([serviceWorkerRegistered])
     .then(() => {

--- a/src/js/ui/stream-config.js
+++ b/src/js/ui/stream-config.js
@@ -1,0 +1,24 @@
+export function initStreamConfig() {
+  const container = document.querySelector('#debug-mode-container');
+  if (!container) return;
+
+  const fieldset = document.createElement('fieldset');
+  fieldset.innerHTML = `
+    <legend>Stream Config</legend>
+    <label><input type="radio" name="stream-strategy" value="static" checked>Static</label>
+    <label><input type="radio" name="stream-strategy" value="live">Live</label>
+  `;
+  container.appendChild(fieldset);
+
+  const radios = fieldset.querySelectorAll('input[name="stream-strategy"]');
+  radios.forEach(radio => {
+    radio.addEventListener('change', () => {
+      if (radio.checked) {
+        window.spwashi.streamStrategy = radio.value;
+        document.dispatchEvent(new CustomEvent('stream-strategy-change', { detail: { strategy: radio.value } }));
+      }
+    });
+  });
+
+  window.spwashi.streamStrategy = 'static';
+}

--- a/src/stylesheets/interaction/interaction.scss
+++ b/src/stylesheets/interaction/interaction.scss
@@ -1,4 +1,4 @@
 @import "./consent";
 @import "./focal-square";
 @import "./interaction-depth";
-@import "./websocket-container";
+@import "./stream-container";

--- a/src/stylesheets/interaction/stream-container.scss
+++ b/src/stylesheets/interaction/stream-container.scss
@@ -1,4 +1,4 @@
-#main-websocket-container {
+#main-stream-container {
   position: fixed;
   bottom: 0;
   right: 0;


### PR DESCRIPTION
## Summary
- rename websocket container to stream container
- support stream config in debug mode
- wire data manager to use selected stream strategy
- update docs and HTML to use new stream container

## Testing
- `yarn build` *(fails: package not present)*

------
https://chatgpt.com/codex/tasks/task_b_68530a41ed10832ab1d9540e6e12c9f6