### PR TITLE
Add Web API docs and mode doc links

### DIFF
--- a/docs/api/modes.md
+++ b/docs/api/modes.md
@@ -1,0 +1,39 @@
+# Stream Mode Web APIs
+
+This document outlines the WebSocket message formats understood by each stream mode.
+
+## Boon
+Messages are JSON objects describing a "boon" node.
+Example sent from the client:
+```json
+{
+  "id": 123,
+  "name": "Example Boon",
+  "x": 0,
+  "y": 0,
+  "z": 0,
+  "boonhonk": {"description": "text", "level": 1, "is_active": true},
+  "image_id": null
+}
+```
+The server echoes a similar structure when broadcasting boon updates.
+
+## Boof
+Boof messages contain textual content. Clients may send plain text or a JSON object `{ "content": "text" }` and receive a similar structure from the server.
+
+## Focal
+Used to update the focal point of the simulation.
+```json
+{
+  "type": "focal-point",
+  "position": {"x": 10, "y": 20},
+  "bounds": {"x1": 0, "y1": 0, "x2": 20, "y2": 40}
+}
+```
+
+## Passive
+Passive mode receives streamed updates but does not send data. Any JSON object broadcast by the server will be displayed.
+
+## Other Modes
+Bane, Bone, Bonk, Honk and Lore share the same pattern as Passive mode. They may be extended later with specific message formats.
+

--- a/docs/websocket-notes.md
+++ b/docs/websocket-notes.md
@@ -5,3 +5,5 @@ This interface exposes nine narrative modes: **Boon**, **Bane**, **Bone**, **Bon
 Each mode's settings are stored locally in `localStorage` and may be transmitted to a backend when the `Send to Backend` button is pressed. To hook in real-time updates, listen to stream messages of the form `{type: '<mode>-settings', data: {...}}` and update the UI using the `handleStreamMessage` method of each handler.
 
 The container uses a `DataManager` abstraction to source data either from static arrays or from a live WebSocket feed. Extend `modeConfig` in `stream-container.js` to point a mode at a live URL when the backend is available.
+
+For detailed message formats see [Stream Mode Web APIs](api/modes.md).

--- a/src/js/config/mode-docs.js
+++ b/src/js/config/mode-docs.js
@@ -1,0 +1,11 @@
+export const MODE_DOCS = {
+  boon: { file: 'docs/api/modes.md#boon' },
+  bane: { file: 'docs/api/modes.md#bane' },
+  bone: { file: 'docs/api/modes.md#bone' },
+  bonk: { file: 'docs/api/modes.md#bonk' },
+  honk: { file: 'docs/api/modes.md#honk' },
+  boof: { url: 'https://example.com/boof-api', file: 'docs/api/modes.md#boof' },
+  lore: { file: 'docs/api/modes.md#lore' },
+  focal: { file: 'docs/api/modes.md#focal' },
+  passive: { file: 'docs/api/modes.md#passive' },
+};

--- a/src/js/ui/modes/bane.js
+++ b/src/js/ui/modes/bane.js
@@ -1,0 +1,4 @@
+import { ConfigModeHandler } from './base.js';
+export class BaneModeHandler extends ConfigModeHandler {
+  constructor(container) { super(container, 'bane'); }
+}

--- a/src/js/ui/modes/base.js
+++ b/src/js/ui/modes/base.js
@@ -1,0 +1,127 @@
+export class ModeHandler {
+  constructor(container) {
+    this.container = container;
+  }
+
+  setupDataManager() {
+    if (!this.container.dataManager) return;
+    this.container.dataManager
+      .getAll()
+      .then((items) => {
+        if (typeof this.renderItems === 'function') {
+          this.renderItems(items);
+        }
+      });
+    if (typeof this.container.dataManager.onUpdate === 'function') {
+      this.updateCb = (item) => {
+        if (typeof this.renderItem === 'function') {
+          this.renderItem(item);
+        }
+      };
+      this.container.dataManager.onUpdate(this.updateCb);
+    }
+  }
+
+  render() {
+    return '';
+  }
+
+  setupEventListeners() {
+    this.setupDataManager();
+  }
+
+  handleStreamMessage(data) {}
+
+  cleanup() {
+    if (this.updateCb && this.container.dataManager) {
+      this.container.dataManager.offUpdate(this.updateCb);
+    }
+  }
+}
+
+export class ConfigModeHandler extends ModeHandler {
+  constructor(container, mode) {
+    super(container);
+    this.mode = mode;
+    this.storageKey = `${mode}-settings`;
+  }
+
+  getDefaults() {
+    return { name: '', description: '', intensity: 5, active: false, visible: true };
+  }
+
+  loadSettings() {
+    try {
+      return JSON.parse(localStorage.getItem(this.storageKey)) || this.getDefaults();
+    } catch {
+      return this.getDefaults();
+    }
+  }
+
+  render() {
+    const vals = this.loadSettings();
+    return `
+      <form class="mode-form" data-mode="${this.mode}">
+        <h3>${this.mode.charAt(0).toUpperCase() + this.mode.slice(1)} Settings</h3>
+        <label>Name<input type="text" class="mode-name" value="${vals.name}"/></label>
+        <label>Description<input type="text" class="mode-description" value="${vals.description}"/></label>
+        <label>Intensity<input type="range" min="1" max="10" class="mode-intensity" value="${vals.intensity}"/></label>
+        <label><input type="checkbox" class="mode-active" ${vals.active ? 'checked' : ''}/>Active</label>
+        <label><input type="checkbox" class="mode-visible" ${vals.visible ? 'checked' : ''}/>Visible</label>
+        <div class="button-group">
+          <button type="button" class="save-settings">Save Settings</button>
+          <button type="button" class="send-settings">Send to Backend</button>
+        </div>
+      </form>
+    `;
+  }
+
+  setupEventListeners() {
+    this.form = this.container.shadow.querySelector(`form[data-mode="${this.mode}"]`);
+    if (!this.form) return;
+    this.nameField = this.form.querySelector('.mode-name');
+    this.descField = this.form.querySelector('.mode-description');
+    this.intensityField = this.form.querySelector('.mode-intensity');
+    this.activeField = this.form.querySelector('.mode-active');
+    this.visibleField = this.form.querySelector('.mode-visible');
+    this.saveBtn = this.form.querySelector('.save-settings');
+    this.sendBtn = this.form.querySelector('.send-settings');
+    this.saveBound = this.saveSettings.bind(this);
+    this.sendBound = this.sendSettings.bind(this);
+    this.saveBtn.addEventListener('click', this.saveBound);
+    this.sendBtn.addEventListener('click', this.sendBound);
+    super.setupEventListeners();
+  }
+
+  getSettings() {
+    return {
+      name: this.nameField.value.trim(),
+      description: this.descField.value.trim(),
+      intensity: parseInt(this.intensityField.value, 10),
+      active: this.activeField.checked,
+      visible: this.visibleField.checked,
+    };
+  }
+
+  saveSettings() {
+    const data = this.getSettings();
+    localStorage.setItem(this.storageKey, JSON.stringify(data));
+    this.container.displayMessage(`${this.mode} settings saved locally`, 'success');
+  }
+
+  sendSettings() {
+    const data = this.getSettings();
+    if (this.container.stream && this.container.stream.readyState === WebSocket.OPEN) {
+      this.container.stream.send(JSON.stringify({ type: `${this.mode}-settings`, data }));
+      this.container.displayMessage(`${this.mode} settings sent`, 'info');
+    } else {
+      this.container.displayMessage('WebSocket not connected. Settings stored locally.', 'warning');
+    }
+  }
+
+  cleanup() {
+    if (this.saveBtn) this.saveBtn.removeEventListener('click', this.saveBound);
+    if (this.sendBtn) this.sendBtn.removeEventListener('click', this.sendBound);
+    super.cleanup();
+  }
+}

--- a/src/js/ui/modes/bone.js
+++ b/src/js/ui/modes/bone.js
@@ -1,0 +1,4 @@
+import { ConfigModeHandler } from './base.js';
+export class BoneModeHandler extends ConfigModeHandler {
+  constructor(container) { super(container, 'bone'); }
+}

--- a/src/js/ui/modes/bonk.js
+++ b/src/js/ui/modes/bonk.js
@@ -1,0 +1,4 @@
+import { ConfigModeHandler } from './base.js';
+export class BonkModeHandler extends ConfigModeHandler {
+  constructor(container) { super(container, 'bonk'); }
+}

--- a/src/js/ui/modes/boof.js
+++ b/src/js/ui/modes/boof.js
@@ -1,0 +1,55 @@
+import { ModeHandler } from './base.js';
+
+export class BoofModeHandler extends ModeHandler {
+  render() {
+    return `
+      <div class="input-wrapper">
+        <label for="boof-input">Enter Boof Message:</label>
+        <input type="text" id="boof-input" class="boof-input" placeholder="Type your message here" />
+        <button class="boof-submit">Send Boof</button>
+      </div>
+    `;
+  }
+
+  setupEventListeners() {
+    this.boofInputField = this.container.shadow.querySelector('.boof-input');
+    this.boofButton = this.container.shadow.querySelector('.boof-submit');
+    this.sendBoofMessageBound = this.sendBoofMessage.bind(this);
+    this.boofButton.addEventListener('click', this.sendBoofMessageBound);
+    super.setupEventListeners();
+  }
+
+  handleStreamMessage(data) {
+    if (data.content) {
+      this.container.displayBoof(data);
+      this.container.dispatchEvent(new CustomEvent('boof-received', { detail: data }));
+    }
+  }
+
+  sendBoofMessage() {
+    const message = this.boofInputField.value.trim();
+    if (message) {
+      this.container.stream.send(message);
+      this.boofInputField.value = '';
+      this.container.displayMessage('Boof message sent', 'success');
+      this.container.dispatchEvent(new CustomEvent('boof-sent', { detail: { content: message } }));
+    } else {
+      this.container.displayMessage('Cannot send an empty Boof message', 'warning');
+    }
+  }
+
+  cleanup() {
+    if (this.boofButton) {
+      this.boofButton.removeEventListener('click', this.sendBoofMessageBound);
+    }
+    super.cleanup();
+  }
+
+  renderItems(items) {
+    items.forEach((item) => this.renderItem(item));
+  }
+
+  renderItem(item) {
+    this.container.displayBoof(item);
+  }
+}

--- a/src/js/ui/modes/boon.js
+++ b/src/js/ui/modes/boon.js
@@ -1,0 +1,122 @@
+import { ModeHandler } from './base.js';
+
+export class BoonModeHandler extends ModeHandler {
+  render() {
+    const defaultValues = {
+      name: 'Default Boon Name',
+      x: 0,
+      y: 0,
+      z: 0,
+      description: 'Default description for the boon',
+      level: 1,
+      isActive: true,
+    };
+
+    return `
+      <div class="boon-form">
+        <h3>Create Boon</h3>
+        <section>
+          <fieldset>
+            <legend>Basic Information</legend>
+            <label for="boon-name">Name:</label>
+            <input type="text" id="boon-name" class="boon-name" placeholder="Enter name" value="${defaultValues.name}" />
+          </fieldset>
+          <fieldset>
+            <legend>Position</legend>
+            <label for="boon-x">X:</label>
+            <input type="number" id="boon-x" class="boon-x" placeholder="X-coordinate" value="${defaultValues.x}" />
+            <label for="boon-y">Y:</label>
+            <input type="number" id="boon-y" class="boon-y" placeholder="Y-coordinate" value="${defaultValues.y}" />
+            <label for="boon-z">Z:</label>
+            <input type="number" id="boon-z" class="boon-z" placeholder="Z-coordinate" value="${defaultValues.z}" />
+          </fieldset>
+          <fieldset>
+            <legend>Boon Details</legend>
+            <label for="boon-description">Description:</label>
+            <input type="text" id="boon-description" class="boon-description" placeholder="Describe the boon" value="${defaultValues.description}" />
+            <label for="boon-level">Level:</label>
+            <input type="number" id="boon-level" class="boon-level" placeholder="Enter level" value="${defaultValues.level}" />
+            <label for="boon-is-active">
+              <input type="checkbox" id="boon-is-active" class="boon-is-active" ${defaultValues.isActive ? 'checked' : ''} />
+              Is Active
+            </label>
+          </fieldset>
+        </section>
+        <button class="boon-submit">Send Boon</button>
+      </div>
+    `;
+  }
+
+  setupEventListeners() {
+    const shadow = this.container.shadow;
+    this.boonNameField = shadow.querySelector('.boon-name');
+    this.boonXField = shadow.querySelector('.boon-x');
+    this.boonYField = shadow.querySelector('.boon-y');
+    this.boonZField = shadow.querySelector('.boon-z');
+    this.boonDescriptionField = shadow.querySelector('.boon-description');
+    this.boonLevelField = shadow.querySelector('.boon-level');
+    this.boonIsActiveField = shadow.querySelector('.boon-is-active');
+    this.boonButton = shadow.querySelector('.boon-submit');
+
+    this.sendBoonMessageBound = this.sendBoonMessage.bind(this);
+    this.boonButton.addEventListener('click', this.sendBoonMessageBound);
+
+    super.setupEventListeners();
+  }
+
+  handleStreamMessage(data) {
+    if (data.id && data.name && data.boonhonk) {
+      this.container.processBoon(data);
+      this.container.dispatchEvent(new CustomEvent('boon-received', { detail: data }));
+    }
+  }
+
+  sendBoonMessage() {
+    const boon = {
+      id: Date.now(),
+      name: this.boonNameField.value.trim(),
+      x: parseFloat(this.boonXField.value),
+      y: parseFloat(this.boonYField.value),
+      z: parseFloat(this.boonZField.value),
+      boonhonk: {
+        description: this.boonDescriptionField.value.trim(),
+        level: parseInt(this.boonLevelField.value, 10),
+        is_active: this.boonIsActiveField.checked,
+      },
+      image_id: null,
+    };
+
+    if (!boon.name || isNaN(boon.x) || isNaN(boon.y) || isNaN(boon.z) || !boon.boonhonk.description || isNaN(boon.boonhonk.level)) {
+      this.container.displayMessage('Please fill in all Boon fields correctly.', 'warning');
+      return;
+    }
+
+    this.container.stream.send(JSON.stringify(boon));
+
+    this.boonNameField.value = '';
+    this.boonXField.value = '';
+    this.boonYField.value = '';
+    this.boonZField.value = '';
+    this.boonDescriptionField.value = '';
+    this.boonLevelField.value = '';
+    this.boonIsActiveField.checked = false;
+
+    this.container.displayMessage('Boon message sent', 'success');
+    this.container.dispatchEvent(new CustomEvent('boon-sent', { detail: boon }));
+  }
+
+  cleanup() {
+    if (this.boonButton) {
+      this.boonButton.removeEventListener('click', this.sendBoonMessageBound);
+    }
+    super.cleanup();
+  }
+
+  renderItems(items) {
+    items.forEach((item) => this.renderItem(item));
+  }
+
+  renderItem(item) {
+    this.container.processBoon(item);
+  }
+}

--- a/src/js/ui/modes/focal.js
+++ b/src/js/ui/modes/focal.js
@@ -1,0 +1,62 @@
+import { ModeHandler } from './base.js';
+import { focalPoint, initFocalSquare } from '../focal-point.js';
+
+export class FocalModeHandler extends ModeHandler {
+  render() {
+    return `
+      <button class="focal-submit">Set Focal Point</button>
+    `;
+  }
+
+  setupEventListeners() {
+    this.focalButton = this.container.shadow.querySelector('.focal-submit');
+    this.setFocalPointBound = this.setFocalPoint.bind(this);
+    this.focalButton.addEventListener('click', this.setFocalPointBound);
+    initFocalSquare();
+    super.setupEventListeners();
+  }
+
+  handleStreamMessage(data) {
+    if (data.type === 'focal-point') {
+      this.container.displayMessage(`Focal point updated: ${JSON.stringify(data.position)}`);
+      this.container.dispatchEvent(new CustomEvent('focal-point-received', { detail: data }));
+    }
+  }
+
+  setFocalPoint() {
+    const bounds = {
+      x1: focalPoint.x - 50,
+      y1: focalPoint.y - 50,
+      x2: focalPoint.x + 50,
+      y2: focalPoint.y + 50,
+    };
+
+    const focalData = {
+      type: 'focal-point',
+      position: { x: focalPoint.x, y: focalPoint.y },
+      bounds,
+    };
+
+    this.container.stream.send(JSON.stringify(focalData));
+    this.container.displayMessage(
+      `Focal point sent with position (${focalData.position.x}, ${focalData.position.y}) and bounds (${bounds.x1}, ${bounds.y1}, ${bounds.x2}, ${bounds.y2})`,
+      'success'
+    );
+    this.container.dispatchEvent(new CustomEvent('focal-point-sent', { detail: focalData }));
+  }
+
+  cleanup() {
+    if (this.focalButton) {
+      this.focalButton.removeEventListener('click', this.setFocalPointBound);
+    }
+    super.cleanup();
+  }
+
+  renderItems(items) {
+    items.forEach((item) => this.renderItem(item));
+  }
+
+  renderItem(item) {
+    this.container.displayMessage(`[focal] ${JSON.stringify(item)}`);
+  }
+}

--- a/src/js/ui/modes/honk.js
+++ b/src/js/ui/modes/honk.js
@@ -1,0 +1,4 @@
+import { ConfigModeHandler } from './base.js';
+export class HonkModeHandler extends ConfigModeHandler {
+  constructor(container) { super(container, 'honk'); }
+}

--- a/src/js/ui/modes/lore.js
+++ b/src/js/ui/modes/lore.js
@@ -1,0 +1,4 @@
+import { ConfigModeHandler } from './base.js';
+export class LoreModeHandler extends ConfigModeHandler {
+  constructor(container) { super(container, 'lore'); }
+}

--- a/src/js/ui/modes/passive.js
+++ b/src/js/ui/modes/passive.js
@@ -1,0 +1,15 @@
+import { ModeHandler } from './base.js';
+
+export class PassiveModeHandler extends ModeHandler {
+  render() {
+    return `<div class="passive-message">Passive mode active. Waiting for updates…</div>`;
+  }
+
+  renderItems(items) {
+    items.forEach((item) => this.renderItem(item));
+  }
+
+  renderItem(item) {
+    this.container.displayMessage(`[passive] ${JSON.stringify(item)}`);
+  }
+}

--- a/src/js/ui/stream-container.js
+++ b/src/js/ui/stream-container.js
@@ -1,8 +1,17 @@
 // stream-container.js
 
 import { NODE_MANAGER } from '../simulation/nodes/nodes';
-import { focalPoint, initFocalSquare } from './focal-point';
 import { DataManager } from '../services/data-manager.js';
+import { MODE_DOCS } from '../config/mode-docs.js';
+import { BoofModeHandler } from './modes/boof.js';
+import { BoonModeHandler } from './modes/boon.js';
+import { BaneModeHandler } from './modes/bane.js';
+import { BoneModeHandler } from './modes/bone.js';
+import { BonkModeHandler } from './modes/bonk.js';
+import { HonkModeHandler } from './modes/honk.js';
+import { LoreModeHandler } from './modes/lore.js';
+import { FocalModeHandler } from './modes/focal.js';
+import { PassiveModeHandler } from './modes/passive.js';
 
 const BOON_ITEMS = [];
 const BANE_ITEMS = [];
@@ -25,435 +34,6 @@ const modeConfig = {
   focal: { strategy: 'static', staticItems: FOCAL_ITEMS, allowedStreams: ['static', 'live'] },
   passive: { strategy: 'static', staticItems: PASSIVE_ITEMS, allowedStreams: ['static', 'live'] },
 };
-
-/**
- * Base class for different modes.
- */
-class ModeHandler {
-  constructor(container) {
-    this.container = container;
-  }
-
-  setupDataManager() {
-    if (!this.container.dataManager) return;
-    this.container.dataManager
-      .getAll()
-      .then((items) => {
-        if (typeof this.renderItems === 'function') {
-          this.renderItems(items);
-        }
-      });
-    if (typeof this.container.dataManager.onUpdate === 'function') {
-      this.updateCb = (item) => {
-        if (typeof this.renderItem === 'function') {
-          this.renderItem(item);
-        }
-      };
-      this.container.dataManager.onUpdate(this.updateCb);
-    }
-  }
-
-  render() {
-    return '';
-  }
-
-  setupEventListeners() {
-    this.setupDataManager();
-  }
-
-  handleStreamMessage(data) {}
-
-  cleanup() {
-    if (this.updateCb && this.container.dataManager) {
-      this.container.dataManager.offUpdate(this.updateCb);
-    }
-  }
-}
-/**
- * Generic configurable mode handler.
- */
-class ConfigModeHandler extends ModeHandler {
-  constructor(container, mode) {
-    super(container);
-    this.mode = mode;
-    this.storageKey = `${mode}-settings`;
-  }
-
-  getDefaults() {
-    return { name: '', description: '', intensity: 5, active: false, visible: true };
-  }
-
-  loadSettings() {
-    try {
-      return JSON.parse(localStorage.getItem(this.storageKey)) || this.getDefaults();
-    } catch {
-      return this.getDefaults();
-    }
-  }
-
-  render() {
-    const vals = this.loadSettings();
-    return `
-      <form class="mode-form" data-mode="${this.mode}">
-        <h3>${this.mode.charAt(0).toUpperCase() + this.mode.slice(1)} Settings</h3>
-        <label>Name<input type="text" class="mode-name" value="${vals.name}"/></label>
-        <label>Description<input type="text" class="mode-description" value="${vals.description}"/></label>
-        <label>Intensity<input type="range" min="1" max="10" class="mode-intensity" value="${vals.intensity}"/></label>
-        <label><input type="checkbox" class="mode-active" ${vals.active ? 'checked' : ''}/>Active</label>
-        <label><input type="checkbox" class="mode-visible" ${vals.visible ? 'checked' : ''}/>Visible</label>
-        <div class="button-group">
-          <button type="button" class="save-settings">Save Settings</button>
-          <button type="button" class="send-settings">Send to Backend</button>
-        </div>
-      </form>
-    `;
-  }
-
-  setupEventListeners() {
-    this.form = this.container.shadow.querySelector(`form[data-mode="${this.mode}"]`);
-    if (!this.form) return;
-    this.nameField = this.form.querySelector('.mode-name');
-    this.descField = this.form.querySelector('.mode-description');
-    this.intensityField = this.form.querySelector('.mode-intensity');
-    this.activeField = this.form.querySelector('.mode-active');
-    this.visibleField = this.form.querySelector('.mode-visible');
-    this.saveBtn = this.form.querySelector('.save-settings');
-    this.sendBtn = this.form.querySelector('.send-settings');
-    this.saveBound = this.saveSettings.bind(this);
-    this.sendBound = this.sendSettings.bind(this);
-    this.saveBtn.addEventListener('click', this.saveBound);
-    this.sendBtn.addEventListener('click', this.sendBound);
-    super.setupEventListeners();
-  }
-
-  getSettings() {
-    return {
-      name: this.nameField.value.trim(),
-      description: this.descField.value.trim(),
-      intensity: parseInt(this.intensityField.value, 10),
-      active: this.activeField.checked,
-      visible: this.visibleField.checked,
-    };
-  }
-
-  saveSettings() {
-    const data = this.getSettings();
-    localStorage.setItem(this.storageKey, JSON.stringify(data));
-    this.container.displayMessage(`${this.mode} settings saved locally`, 'success');
-  }
-
-  sendSettings() {
-    const data = this.getSettings();
-    if (this.container.stream && this.container.stream.readyState === WebSocket.OPEN) {
-      this.container.stream.send(JSON.stringify({ type: `${this.mode}-settings`, data }));
-      this.container.displayMessage(`${this.mode} settings sent`, 'info');
-    } else {
-      this.container.displayMessage('WebSocket not connected. Settings stored locally.', 'warning');
-    }
-  }
-
-  cleanup() {
-    if (this.saveBtn) this.saveBtn.removeEventListener('click', this.saveBound);
-    if (this.sendBtn) this.sendBtn.removeEventListener('click', this.sendBound);
-    super.cleanup();
-  }
-}
-
-/**
- * Handler for Boof mode.
- */
-class BoofModeHandler extends ModeHandler {
-  render() {
-    return `
-      <div class="input-wrapper">
-        <label for="boof-input">Enter Boof Message:</label>
-        <input type="text" id="boof-input" class="boof-input" placeholder="Type your message here" />
-        <button class="boof-submit">Send Boof</button>
-      </div>
-    `;
-  }
-
-  setupEventListeners() {
-    this.boofInputField = this.container.shadow.querySelector('.boof-input');
-    this.boofButton = this.container.shadow.querySelector('.boof-submit');
-    this.sendBoofMessageBound = this.sendBoofMessage.bind(this);
-    this.boofButton.addEventListener('click', this.sendBoofMessageBound);
-    super.setupEventListeners();
-  }
-
-  handleStreamMessage(data) {
-    if (data.content) {
-      this.container.displayBoof(data);
-      // Emit custom event
-      this.container.dispatchEvent(new CustomEvent('boof-received', { detail: data }));
-    }
-  }
-
-  sendBoofMessage() {
-    const message = this.boofInputField.value.trim();
-    if (message) {
-      this.container.stream.send(message);
-      this.boofInputField.value = ''; // Clear the input field after sending
-      this.container.displayMessage('Boof message sent', 'success');
-      // Emit custom event
-      this.container.dispatchEvent(new CustomEvent('boof-sent', { detail: { content: message } }));
-    } else {
-      this.container.displayMessage('Cannot send an empty Boof message', 'warning');
-    }
-  }
-
-  cleanup() {
-    if (this.boofButton) {
-      this.boofButton.removeEventListener('click', this.sendBoofMessageBound);
-    }
-    super.cleanup();
-  }
-
-  renderItems(items) {
-    items.forEach((item) => this.renderItem(item));
-  }
-
-  renderItem(item) {
-    this.container.displayBoof(item);
-  }
-}
-
-/**
- * Handler for Boon mode.
- */
-class BoonModeHandler extends ModeHandler {
-  render() {
-    // Set default values
-    const defaultValues = {
-      name: 'Default Boon Name',
-      x: 0,
-      y: 0,
-      z: 0,
-      description: 'Default description for the boon',
-      level: 1,
-      isActive: true,
-    };
-
-    return `
-      <div class="boon-form">
-        <h3>Create Boon</h3>
-        <section>
-          <fieldset>
-            <legend>Basic Information</legend>
-            <label for="boon-name">Name:</label>
-            <input type="text" id="boon-name" class="boon-name" placeholder="Enter name" value="${defaultValues.name}" />
-          </fieldset>
-          <fieldset>
-            <legend>Position</legend>
-            <label for="boon-x">X:</label>
-            <input type="number" id="boon-x" class="boon-x" placeholder="X-coordinate" value="${defaultValues.x}" />
-            <label for="boon-y">Y:</label>
-            <input type="number" id="boon-y" class="boon-y" placeholder="Y-coordinate" value="${defaultValues.y}" />
-            <label for="boon-z">Z:</label>
-            <input type="number" id="boon-z" class="boon-z" placeholder="Z-coordinate" value="${defaultValues.z}" />
-          </fieldset>
-          <fieldset>
-            <legend>Boon Details</legend>
-            <label for="boon-description">Description:</label>
-            <input type="text" id="boon-description" class="boon-description" placeholder="Describe the boon" value="${defaultValues.description}" />
-            <label for="boon-level">Level:</label>
-            <input type="number" id="boon-level" class="boon-level" placeholder="Enter level" value="${defaultValues.level}" />
-            <label for="boon-is-active">
-              <input type="checkbox" id="boon-is-active" class="boon-is-active" ${defaultValues.isActive ? 'checked' : ''} />
-              Is Active
-            </label>
-          </fieldset>
-        </section>
-        <button class="boon-submit">Send Boon</button>
-      </div>
-    `;
-  }
-
-  setupEventListeners() {
-    const shadow = this.container.shadow;
-    this.boonNameField = shadow.querySelector('.boon-name');
-    this.boonXField = shadow.querySelector('.boon-x');
-    this.boonYField = shadow.querySelector('.boon-y');
-    this.boonZField = shadow.querySelector('.boon-z');
-    this.boonDescriptionField = shadow.querySelector('.boon-description');
-    this.boonLevelField = shadow.querySelector('.boon-level');
-    this.boonIsActiveField = shadow.querySelector('.boon-is-active');
-    this.boonButton = shadow.querySelector('.boon-submit');
-
-    this.sendBoonMessageBound = this.sendBoonMessage.bind(this);
-    this.boonButton.addEventListener('click', this.sendBoonMessageBound);
-
-    super.setupEventListeners();
-  }
-
-  handleStreamMessage(data) {
-    if (data.id && data.name && data.boonhonk) {
-      this.container.processBoon(data);
-      // Emit custom event
-      this.container.dispatchEvent(new CustomEvent('boon-received', { detail: data }));
-    }
-  }
-
-  sendBoonMessage() {
-    const boon = {
-      id: Date.now(),
-      name: this.boonNameField.value.trim(),
-      x: parseFloat(this.boonXField.value),
-      y: parseFloat(this.boonYField.value),
-      z: parseFloat(this.boonZField.value),
-      boonhonk: {
-        description: this.boonDescriptionField.value.trim(),
-        level: parseInt(this.boonLevelField.value, 10),
-        is_active: this.boonIsActiveField.checked,
-      },
-      image_id: null,
-    };
-
-    // Validate the boon data
-    if (
-        !boon.name ||
-        isNaN(boon.x) ||
-        isNaN(boon.y) ||
-        isNaN(boon.z) ||
-        !boon.boonhonk.description ||
-        isNaN(boon.boonhonk.level)
-    ) {
-      this.container.displayMessage('Please fill in all Boon fields correctly.', 'warning');
-      return;
-    }
-
-    // Send the Boon as a JSON string
-    this.container.stream.send(JSON.stringify(boon));
-
-    // Clear the form fields
-    this.boonNameField.value = '';
-    this.boonXField.value = '';
-    this.boonYField.value = '';
-    this.boonZField.value = '';
-    this.boonDescriptionField.value = '';
-    this.boonLevelField.value = '';
-    this.boonIsActiveField.checked = false;
-
-    this.container.displayMessage('Boon message sent', 'success');
-    // Emit custom event
-    this.container.dispatchEvent(new CustomEvent('boon-sent', { detail: boon }));
-  }
-
-  cleanup() {
-    if (this.boonButton) {
-      this.boonButton.removeEventListener('click', this.sendBoonMessageBound);
-    }
-    super.cleanup();
-  }
-
-  renderItems(items) {
-    items.forEach((item) => this.renderItem(item));
-  }
-
-  renderItem(item) {
-    this.container.processBoon(item);
-  }
-}
-
-/**
- * Handler for Focal mode.
- */
-class FocalModeHandler extends ModeHandler {
-  render() {
-    return `
-      <button class="focal-submit">Set Focal Point</button>
-    `;
-  }
-
-  setupEventListeners() {
-    this.focalButton = this.container.shadow.querySelector('.focal-submit');
-    this.setFocalPointBound = this.setFocalPoint.bind(this);
-    this.focalButton.addEventListener('click', this.setFocalPointBound);
-    initFocalSquare();
-    super.setupEventListeners();
-  }
-
-  handleStreamMessage(data) {
-    if (data.type === 'focal-point') {
-      this.container.displayMessage(`Focal point updated: ${JSON.stringify(data.position)}`);
-      // Emit custom event
-      this.container.dispatchEvent(new CustomEvent('focal-point-received', { detail: data }));
-    }
-  }
-
-  setFocalPoint() {
-    const bounds = {
-      x1: focalPoint.x - 50,
-      y1: focalPoint.y - 50,
-      x2: focalPoint.x + 50,
-      y2: focalPoint.y + 50,
-    };
-
-    const focalData = {
-      type: 'focal-point',
-      position: { x: focalPoint.x, y: focalPoint.y },
-      bounds,
-    };
-
-    this.container.stream.send(JSON.stringify(focalData));
-    this.container.displayMessage(
-        `Focal point sent with position (${focalData.position.x}, ${focalData.position.y}) and bounds (${bounds.x1}, ${bounds.y1}, ${bounds.x2}, ${bounds.y2})`,
-        'success'
-    );
-    // Emit custom event
-    this.container.dispatchEvent(new CustomEvent('focal-point-sent', { detail: focalData }));
-  }
-
-  cleanup() {
-    if (this.focalButton) {
-      this.focalButton.removeEventListener('click', this.setFocalPointBound);
-    }
-    super.cleanup();
-  }
-
-  renderItems(items) {
-    items.forEach((item) => this.renderItem(item));
-  }
-
-  renderItem(item) {
-    this.container.displayMessage(`[focal] ${JSON.stringify(item)}`);
-  }
-}
-
-/**
- * Handler for Passive mode.
- */
-class PassiveModeHandler extends ModeHandler {
-  render() {
-    return `<div class="passive-message">Passive mode active. Waiting for updates…</div>`;
-  }
-
-  renderItems(items) {
-    items.forEach((item) => this.renderItem(item));
-  }
-
-  renderItem(item) {
-    this.container.displayMessage(`[passive] ${JSON.stringify(item)}`);
-  }
-}
-
-/**
-/** Generic handlers for additional modes **/
-class BaneModeHandler extends ConfigModeHandler {
-  constructor(container) { super(container, 'bane'); }
-}
-class BoneModeHandler extends ConfigModeHandler {
-  constructor(container) { super(container, 'bone'); }
-}
-class BonkModeHandler extends ConfigModeHandler {
-  constructor(container) { super(container, 'bonk'); }
-}
-class HonkModeHandler extends ConfigModeHandler {
-  constructor(container) { super(container, 'honk'); }
-}
-class LoreModeHandler extends ConfigModeHandler {
-  constructor(container) { super(container, "lore"); }
-}
 /**
  * Main stream container class.
  */
@@ -539,6 +119,9 @@ class SpwashiStreamContainer extends HTMLElement {
         )
         .join('');
 
+    const docInfo = MODE_DOCS[this.currentMode] || {};
+    const docsLink = docInfo.url || docInfo.file || '';
+
     let modeSpecificHtml = '';
     if (this.modeHandlers[this.currentMode]) {
       modeSpecificHtml = this.modeHandlers[this.currentMode].prototype.render();
@@ -604,10 +187,16 @@ class SpwashiStreamContainer extends HTMLElement {
         }
         .mode-selector {
           margin-bottom: 1rem;
+          display: flex;
+          align-items: center;
+          gap: 0.5rem;
         }
         .mode-selector select {
           padding: 0.5rem;
           font-size: 1rem;
+        }
+        .mode-docs-link {
+          font-size: 0.8rem;
         }
         .message.info {
           color: var(--info-color, #00f);
@@ -632,6 +221,7 @@ class SpwashiStreamContainer extends HTMLElement {
             ${optionsHtml}
           </select>
         </label>
+        ${docsLink ? `<a href="${docsLink}" class="mode-docs-link" target="_blank" rel="noopener">API Docs</a>` : ''}
       </div>
       <div class="response-wrapper" aria-live="polite"></div>
       ${modeSpecificHtml}


### PR DESCRIPTION
## Summary
- document how each stream mode communicates over WebSockets
- link the new docs from existing notes
- provide `MODE_DOCS` configuration
- show "API Docs" link in the StreamContainer
- refactor stream-container modes into their own files

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_68530d82d59c832abd2d2ae0e5b0cb21