### PR TITLE
Normalize initial UI hydration

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,6 +1,4 @@
-import {initFocalSquare} from "./ui/focal-point";
-import {initH1} from "./ui/h1";
-import {initUi} from "./init/ui";
+import {hydrateUi} from "./init/hydrate-ui";
 import {initRoot} from "./init/root";
 import {initSvgEvents} from "./simulation/events";
 import {simulationElements} from "./simulation/basic";
@@ -8,8 +6,6 @@ import {initParameters} from "./init/parameters/init";
 import {loadParameters} from "./init/parameters/read";
 import {initSite} from "./init/site";
 import {initAnalytics} from "./meta/analytics";
-import {initStreamContainer} from "./ui/stream-container";
-import {initStreamConfig} from "./ui/stream-config";
 
 const versions = {
   'v0.0.1': {
@@ -50,13 +46,9 @@ export async function app() {
 
   // primary interactive elements
   initSvgEvents(simulationElements.svg);
-  initFocalSquare();
-  initH1();
 
   // progressive enhancement
-  initUi(window.spwashi.initialMode);
-  initStreamContainer();
-  initStreamConfig();
+  hydrateUi(window.spwashi.initialMode);
 
   return Promise.all([serviceWorkerRegistered])
     .then(() => {

--- a/src/js/init/hydrate-ui.js
+++ b/src/js/init/hydrate-ui.js
@@ -1,0 +1,13 @@
+import {initFocalSquare} from "../ui/focal-point";
+import {initH1} from "../ui/h1";
+import {initUi} from "./ui";
+import {initStreamContainer} from "../ui/stream-container";
+import {initStreamConfig} from "../ui/stream-config";
+
+export function hydrateUi(mode = window.spwashi.initialMode) {
+  initFocalSquare();
+  initH1();
+  initUi(mode);
+  initStreamContainer();
+  initStreamConfig();
+}

--- a/src/js/ui/stream-container.js
+++ b/src/js/ui/stream-container.js
@@ -381,5 +381,14 @@ class SpwashiStreamContainer extends HTMLElement {
  * Initializes and defines the custom stream container element.
 */
 export function initStreamContainer() {
-  customElements.define('spwashi-stream-container', SpwashiStreamContainer);
+  if (!customElements.get('spwashi-stream-container')) {
+    customElements.define('spwashi-stream-container', SpwashiStreamContainer);
+  }
+  document
+    .querySelectorAll('spwashi-stream-container')
+    .forEach((el) => {
+      if (typeof el.setupStreamContainer === 'function') {
+        el.setupStreamContainer();
+      }
+    });
 }


### PR DESCRIPTION
## Summary
- centralize DOM hydration via `hydrateUi`
- call new helper from the main app boot
- hydrate stream container elements on load

## Testing
- `yarn build` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_b_685313945188832a91f6ced4937c8a4d