### PR TITLE
Add basic README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,38 @@
+# Factshift Web Client
+
+This repository contains the front‑end code for **app.factshift.com**. The project is built with [Vite](https://vitejs.dev/) and uses a variety of client‑side libraries to power a real‑time stream interface.
+
+## Installation
+
+Use `npm` to install dependencies:
+
+```bash
+npm install
+```
+
+## Development
+
+Start a local development server:
+
+```bash
+npm start
+```
+
+## Building
+
+Create a production build:
+
+```bash
+npm run build
+```
+
+Preview the built files locally:
+
+```bash
+npm run serve
+```
+
+## Initialization
+
+For details on how the initialization pipeline works, see [docs/init-pipeline.md](docs/init-pipeline.md).
+


### PR DESCRIPTION
## Summary
- document Factshift web client purpose
- show npm-based install, development, build, and serve commands
- link to docs/init-pipeline.md for initialization notes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_685323974108832aa40d8d148bf6c8db