### PR TITLE
Implement runInitPipeline and docs

### DIFF
--- a/docs/init-pipeline.md
+++ b/docs/init-pipeline.md
@@ -1,0 +1,18 @@
+# Initialization Pipeline
+
+The `runInitPipeline` utility executes an array of setup steps. Each item in the
+pipeline is called in order. If a step returns a Promise it is awaited before
+continuing to the next step, so both synchronous and asynchronous functions can
+be mixed freely.
+
+```javascript
+import { runInitPipeline } from '../bootstrap/run-init-pipeline';
+
+const steps = [
+  () => console.log('sync step'),
+  async () => fetch('/some/resource')
+];
+
+await runInitPipeline(steps);
+```
+

--- a/src/js/bootstrap/run-init-pipeline.js
+++ b/src/js/bootstrap/run-init-pipeline.js
@@ -1,0 +1,5 @@
+export async function runInitPipeline(steps) {
+  for (const fn of steps) {
+    await fn();
+  }
+}


### PR DESCRIPTION
## Summary
- add `runInitPipeline` helper to run setup steps sequentially
- document pipeline usage in `docs/init-pipeline.md`

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_6853238dac60832aafa13f7da6b0a5b0