### PR TITLE
Implement fallback loading states for modes

### DIFF
--- a/src/js/services/data-manager.js
+++ b/src/js/services/data-manager.js
@@ -13,7 +13,14 @@ export class DataManager {
   }
 
   getAll() {
-    return this.source.fetchAll();
+    try {
+      const res = this.source.fetchAll();
+      return res instanceof Promise ? res : Promise.resolve(res);
+    } catch (err) {
+      this.source.error = err;
+      this.source.loading = false;
+      return Promise.reject(err);
+    }
   }
 
   getOne(id) {
@@ -30,5 +37,17 @@ export class DataManager {
     if (this.source.unsubscribeUpdates) {
       this.source.unsubscribeUpdates(cb);
     }
+  }
+
+  get loading() {
+    return this.source.loading;
+  }
+
+  get error() {
+    return this.source.error;
+  }
+
+  get loaded() {
+    return this.source.loaded;
   }
 }

--- a/src/js/stream-modes/bane.js
+++ b/src/js/stream-modes/bane.js
@@ -1,4 +1,7 @@
 import { ConfigModeHandler } from './base.js';
 export class BaneModeHandler extends ConfigModeHandler {
   constructor(container) { super(container, 'bane'); }
+  fallback() {
+    return `<div class="bane-loading">Loading Bane...</div>`;
+  }
 }

--- a/src/js/stream-modes/base.js
+++ b/src/js/stream-modes/base.js
@@ -3,15 +3,33 @@ export class ModeHandler {
     this.container = container;
   }
 
+  fallback() {
+    return `<div class="mode-loading">Loading...</div>`;
+  }
+
   setupDataManager() {
     if (!this.container.dataManager) return;
-    this.container.dataManager
-      .getAll()
-      .then((items) => {
+    if (!this.container.dataManager.loaded) {
+      this.container.startLoading();
+      Promise.resolve(this.container.dataManager.getAll())
+        .then((items) => {
+          if (typeof this.renderItems === 'function') {
+            this.renderItems(items);
+          }
+        })
+        .catch((err) => {
+          this.container.setLoadError(err);
+        })
+        .finally(() => {
+          this.container.finishLoading();
+        });
+    } else {
+      Promise.resolve(this.container.dataManager.getAll()).then((items) => {
         if (typeof this.renderItems === 'function') {
           this.renderItems(items);
         }
       });
+    }
     if (typeof this.container.dataManager.onUpdate === 'function') {
       this.updateCb = (item) => {
         if (typeof this.renderItem === 'function') {

--- a/src/js/stream-modes/bone.js
+++ b/src/js/stream-modes/bone.js
@@ -1,4 +1,7 @@
 import { ConfigModeHandler } from './base.js';
 export class BoneModeHandler extends ConfigModeHandler {
   constructor(container) { super(container, 'bone'); }
+  fallback() {
+    return `<div class="bone-loading">Loading Bone...</div>`;
+  }
 }

--- a/src/js/stream-modes/bonk.js
+++ b/src/js/stream-modes/bonk.js
@@ -1,4 +1,7 @@
 import { ConfigModeHandler } from './base.js';
 export class BonkModeHandler extends ConfigModeHandler {
   constructor(container) { super(container, 'bonk'); }
+  fallback() {
+    return `<div class="bonk-loading">Loading Bonk...</div>`;
+  }
 }

--- a/src/js/stream-modes/boof.js
+++ b/src/js/stream-modes/boof.js
@@ -1,6 +1,9 @@
 import { ModeHandler } from './base.js';
 
 export class BoofModeHandler extends ModeHandler {
+  fallback() {
+    return `<div class="boof-loading">Loading Boof...</div>`;
+  }
   render() {
     return `
       <div class="input-wrapper">

--- a/src/js/stream-modes/boon.js
+++ b/src/js/stream-modes/boon.js
@@ -1,6 +1,9 @@
 import { ModeHandler } from './base.js';
 
 export class BoonModeHandler extends ModeHandler {
+  fallback() {
+    return `<div class="boon-loading">Loading Boons...</div>`;
+  }
   render() {
     const defaultValues = {
       name: 'Default Boon Name',

--- a/src/js/stream-modes/focal.js
+++ b/src/js/stream-modes/focal.js
@@ -2,6 +2,9 @@ import { ModeHandler } from './base.js';
 import { focalPoint, initFocalSquare } from '../focal-point.js';
 
 export class FocalModeHandler extends ModeHandler {
+  fallback() {
+    return `<div class="focal-loading">Loading Focal...</div>`;
+  }
   render() {
     return `
       <button class="focal-submit">Set Focal Point</button>

--- a/src/js/stream-modes/honk.js
+++ b/src/js/stream-modes/honk.js
@@ -1,4 +1,7 @@
 import { ConfigModeHandler } from './base.js';
 export class HonkModeHandler extends ConfigModeHandler {
   constructor(container) { super(container, 'honk'); }
+  fallback() {
+    return `<div class="honk-loading">Loading Honk...</div>`;
+  }
 }

--- a/src/js/stream-modes/lore.js
+++ b/src/js/stream-modes/lore.js
@@ -1,4 +1,7 @@
 import { ConfigModeHandler } from './base.js';
 export class LoreModeHandler extends ConfigModeHandler {
   constructor(container) { super(container, 'lore'); }
+  fallback() {
+    return `<div class="lore-loading">Loading Lore...</div>`;
+  }
 }

--- a/src/js/stream-modes/passive.js
+++ b/src/js/stream-modes/passive.js
@@ -1,6 +1,9 @@
 import { ModeHandler } from './base.js';
 
 export class PassiveModeHandler extends ModeHandler {
+  fallback() {
+    return `<div class="passive-loading">Loading Passive...</div>`;
+  }
   render() {
     return `<div class="passive-message">Passive mode active. Waiting for updates…</div>`;
   }


### PR DESCRIPTION
## Summary
- add loading/error state to data sources and DataManager
- add fallback methods to ModeHandlers
- update stream container to show mode-specific fallback while data loads
- re-render container after data load completes

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_685328fcdc98832aad5cbeefb88a101e