### PR TITLE
Fix service worker version references

### DIFF
--- a/public/v0.0.1/service-worker.js
+++ b/public/v0.0.1/service-worker.js
@@ -1,4 +1,4 @@
-const appVersion = 'v0.0.2-alpha';
+const appVersion = 'v0.0.1';
 const cacheName  = `serviceworker@${appVersion}`;
 
 const staticAssets = [

--- a/public/v0.0.2-alpha/service-worker.js
+++ b/public/v0.0.2-alpha/service-worker.js
@@ -1,4 +1,4 @@
-const appVersion = 'v0.0.1';
+const appVersion = 'v0.0.2-alpha';
 const cacheName  = `serviceworker@${appVersion}`;
 
 const staticAssets =


### PR DESCRIPTION
## Summary
- ensure service worker version constants match their folders

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_68532e4a9e50832a9974b2d5838fc673