### PR TITLE
Implement data source cleanup

### DIFF
--- a/docs/websocket-notes.md
+++ b/docs/websocket-notes.md
@@ -6,4 +6,6 @@ Each mode's settings are stored locally in `localStorage` and may be transmitted
 
 The container uses a `DataManager` abstraction to source data either from static arrays or from a live WebSocket feed. Extend `modeConfig` in `stream-container.js` to point a mode at a live URL when the backend is available.
 
+`LiveDataSource` now exposes a `close()` method. `ModeHandler.cleanup()` invokes this when present so switching modes or stream strategies cleans up the previous connection and callbacks.
+
 For detailed message formats see [Stream Mode Web APIs](api/modes.md).

--- a/src/js/services/data-sources.js
+++ b/src/js/services/data-sources.js
@@ -96,4 +96,15 @@ export class LiveDataSource extends DataSource {
   unsubscribeUpdates(cb) {
     this.callbacks.delete(cb);
   }
+
+  close() {
+    if (this.ws && this.ws.readyState !== WebSocket.CLOSED) {
+      try {
+        this.ws.close();
+      } catch (err) {
+        console.warn('Failed to close WebSocket', err);
+      }
+    }
+    this.callbacks.clear();
+  }
 }

--- a/src/js/stream-modes/base.js
+++ b/src/js/stream-modes/base.js
@@ -54,6 +54,10 @@ export class ModeHandler {
     if (this.updateCb && this.container.dataManager) {
       this.container.dataManager.offUpdate(this.updateCb);
     }
+    const src = this.container.dataManager && this.container.dataManager.source;
+    if (src && typeof src.close === 'function') {
+      src.close();
+    }
   }
 }
 

--- a/src/js/ui/components/stream-container.js
+++ b/src/js/ui/components/stream-container.js
@@ -295,6 +295,13 @@ class SpwashiStreamContainer extends HTMLElement {
    * Handles the mode change event.
    */
   handleModeChange() {
+    if (this.currentModeHandler) {
+      this.currentModeHandler.cleanup();
+      this.currentModeHandler = null;
+    }
+    if (this.dataManager && this.dataManager.source && typeof this.dataManager.source.close === 'function') {
+      this.dataManager.source.close();
+    }
     this.currentMode = this.modeSelector.value;
     this.initDataManager();
     this.render(); // Re-render the UI based on the new mode
@@ -303,6 +310,13 @@ class SpwashiStreamContainer extends HTMLElement {
   }
 
   handleStreamStrategyChange() {
+    if (this.currentModeHandler) {
+      this.currentModeHandler.cleanup();
+      this.currentModeHandler = null;
+    }
+    if (this.dataManager && this.dataManager.source && typeof this.dataManager.source.close === 'function') {
+      this.dataManager.source.close();
+    }
     this.initDataManager();
     this.render();
   }


### PR DESCRIPTION
## Summary
- allow `LiveDataSource` instances to be closed
- close data sources when changing mode or stream strategy
- document WebSocket cleanup behaviour

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_68532e5b4dc8832a9bc51274aa851daf