### PR TITLE
Add duplicate and cycle detection to init pipeline

### DIFF
--- a/docs/init-pipeline.md
+++ b/docs/init-pipeline.md
@@ -27,3 +27,7 @@ addInitSteps([
 ```
 
 Here `c` runs after `a` and `b` despite not specifying a priority. Lower priority values run earlier.
+
+Duplicate step ids are not allowed and will throw an error when added. The
+pipeline also detects circular dependencies between steps and throws an error if
+a cycle is found during sorting.


### PR DESCRIPTION
## Summary
- prevent duplicate step IDs when adding init steps
- detect circular dependencies in `sortSteps`
- document duplicate and cycle errors

## Testing
- `yarn build` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_b_685332cc7540832a816eb8ab4e1fc6e1