### PR TITLE
Add phased init pipeline

### DIFF
--- a/docs/init-pipeline.md
+++ b/docs/init-pipeline.md
@@ -3,18 +3,19 @@
 The bootstrap folder exposes a small pipeline utility for organizing startup routines.
 
 ```javascript
-import { addInitSteps, runInitPipeline } from '../src/js/bootstrap/init-pipeline';
+import { addInitSteps, runInitPipeline, InitPhase } from '../src/js/bootstrap/init-pipeline';
+import { stepsById } from '../src/js/bootstrap/init-steps';
 
 addInitSteps([
-  { id: 'analytics', init: initAnalytics, priority: 0 },
-  { id: 'parameters', init: initParameters, priority: 1 },
-  { id: 'ui', init: hydrateUi, priority: 2, dependsOn: ['parameters'] },
+  { ...stepsById.analytics, phase: InitPhase.BOOT },
+  { ...stepsById.parameters, phase: InitPhase.BOOT },
+  { ...stepsById.ui, phase: InitPhase.UI, dependsOn: [stepsById.parameters] },
 ]);
 
 await runInitPipeline();
 ```
 
-`addInitSteps` accepts either an object mapping step ids to functions or an array of step objects. Each step object has the shape `{id, init, priority?, dependsOn?}`. Steps are sorted before execution by priority and their declared dependencies.
+`addInitSteps` accepts either an object mapping step ids to functions or an array of step objects. Each step object has the shape `{id, init, priority?, dependsOn?, phase?}`. The `dependsOn` list may contain step ids or references to other step objects. Steps are sorted before execution first by their phase, then by priority and finally their declared dependencies.
 
 ### Example with Priorities and Dependencies
 
@@ -31,3 +32,13 @@ Here `c` runs after `a` and `b` despite not specifying a priority. Lower priorit
 Duplicate step ids are not allowed and will throw an error when added. The
 pipeline also detects circular dependencies between steps and throws an error if
 a cycle is found during sorting.
+
+### Phases
+
+Steps can optionally specify a `phase` that groups them into broad buckets of work.
+Phases are defined in the exported `InitPhase` enum with the values `BOOT`, `UI` and `DEFERRED`.
+The sorter runs all `boot` phase steps before `ui` steps, followed by `deferred` steps.
+Any step without a known phase is treated as `deferred`.
+
+Phases are useful for keeping lightweight initialization logic (`boot`) separate
+from user interface startup (`ui`) or work that can be postponed (`deferred`).

--- a/src/js/bootstrap/init-steps/index.js
+++ b/src/js/bootstrap/init-steps/index.js
@@ -1,3 +1,4 @@
+import { InitPhase } from '../init-pipeline';
 import { initAnalytics } from '../meta/analytics';
 import { initParameters } from '../bootstrap/parameters/init';
 import { initRoot } from '../bootstrap/root';
@@ -7,35 +8,60 @@ import { initSvgEvents } from '../simulation/events';
 import { simulationElements } from '../simulation/basic';
 import { hydrateUi } from '../bootstrap/hydrate-ui';
 
-export const analyticsStep = { id: 'analytics', init: initAnalytics, priority: 0 };
-export const parametersStep = { id: 'parameters', init: initParameters, priority: 1 };
-export const rootStep = { id: 'root', init: initRoot, priority: 2 };
-export const siteStep = { id: 'site', init: initSite, priority: 3 };
+export const analyticsStep = {
+  id: 'analytics',
+  init: initAnalytics,
+  priority: 0,
+  phase: InitPhase.BOOT,
+};
+export const parametersStep = {
+  id: 'parameters',
+  init: initParameters,
+  priority: 1,
+  phase: InitPhase.BOOT,
+};
+export const rootStep = {
+  id: 'root',
+  init: initRoot,
+  priority: 2,
+  phase: InitPhase.BOOT,
+};
+export const siteStep = {
+  id: 'site',
+  init: initSite,
+  priority: 3,
+  phase: InitPhase.BOOT,
+};
 export const queryParamsStep = {
   id: 'queryParams',
   init: () => loadParameters(new URLSearchParams(window.location.search)),
   priority: 4,
-  dependsOn: ['parameters'],
+  phase: InitPhase.BOOT,
+  dependsOn: [parametersStep],
 };
 export const svgStep = {
   id: 'svg',
   init: () => initSvgEvents(simulationElements.svg),
   priority: 5,
-  dependsOn: ['root'],
+  phase: InitPhase.UI,
+  dependsOn: [rootStep],
 };
 export const uiStep = {
   id: 'ui',
   init: () => hydrateUi(window.spwashi.initialMode),
   priority: 6,
-  dependsOn: ['svg', 'parameters'],
+  phase: InitPhase.UI,
+  dependsOn: [svgStep, parametersStep],
 };
 
-export const defaultInitSteps = [
-  analyticsStep,
-  parametersStep,
-  rootStep,
-  siteStep,
-  queryParamsStep,
-  svgStep,
-  uiStep,
-];
+export const stepsById = {
+  analytics: analyticsStep,
+  parameters: parametersStep,
+  root: rootStep,
+  site: siteStep,
+  queryParams: queryParamsStep,
+  svg: svgStep,
+  ui: uiStep,
+};
+
+export const defaultInitSteps = Object.values(stepsById);


### PR DESCRIPTION
## Summary
- support optional `phase` field on init steps
- order init steps by phase first then priority
- tag default steps with a phase in `init-steps/index.js`
- allow dependencies to reference step objects directly
- document phases and ordering

## Testing
- `yarn build` *(fails: package not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_b_6853367c71f4832aa1f62fc3cc7c5dc4