### PR TITLE
Improve svg and event setup

### DIFF
--- a/src/js/bootstrap/init-steps/index.js
+++ b/src/js/bootstrap/init-steps/index.js
@@ -5,7 +5,7 @@ import { initRoot } from '../bootstrap/root';
 import { initSite } from '../bootstrap/site';
 import { loadParameters } from '../bootstrap/parameters/read';
 import { initSvgEvents } from '../simulation/events';
-import { simulationElements } from '../simulation/basic';
+import { getSimulationElements } from '../simulation/basic';
 import { hydrateUi } from '../bootstrap/hydrate-ui';
 
 export const analyticsStep = {
@@ -41,7 +41,7 @@ export const queryParamsStep = {
 };
 export const svgStep = {
   id: 'svg',
-  init: () => initSvgEvents(simulationElements.svg),
+  init: () => initSvgEvents(getSimulationElements().svg),
   priority: 5,
   phase: InitPhase.UI,
   dependsOn: [rootStep],

--- a/src/js/simulation/basic.js
+++ b/src/js/simulation/basic.js
@@ -1,9 +1,10 @@
 import {select} from "d3";
 
+let simulationElements = null;
+
 function initSvg() {
   const svg    = select("svg#simulation");
   const g      = svg.select('g.simulation-content');
-  const rectsG = g.select('g.rects');
   const edges  = g.select('g.edges');
   const nodes  = g.select('g.nodes');
 
@@ -11,8 +12,15 @@ function initSvg() {
     svg,
     wrapper:      g,
     edgesWrapper: edges,
-    nodesWrapper: nodes
+    nodesWrapper: nodes,
   };
+}
+
+export function getSimulationElements() {
+  if (!simulationElements) {
+    simulationElements = initSvg();
+  }
+  return simulationElements;
 }
 
 export function initSvgProperties(svg) {
@@ -30,4 +38,3 @@ export function initSvgProperties(svg) {
   document.documentElement.style.setProperty('--page-margin-x', offsetX + 'px');
 }
 
-export const simulationElements = initSvg();

--- a/src/js/simulation/events.js
+++ b/src/js/simulation/events.js
@@ -2,12 +2,13 @@ import {drag, extent, zoom} from "d3";
 import {forEachNode}        from "./nodes/data/operate";
 import {logMainEvent}       from "./nodes/ui/circle";
 import {selectNodesInRect}  from "./nodes/data/selectors/multiple";
-import {simulationElements} from "./basic";
+import {getSimulationElements} from "./basic";
 
 const nodeG_offset    = {x: 0, y: 0};
 const nodeG_transform = {x: 0, y: 0};
 
 export function initSvgEvents(svg) {
+  const simulationElements = getSimulationElements();
   if (window.spwashi.parameters.canzoom) {
     svg
       .call(zoom()
@@ -24,6 +25,7 @@ export function initSvgEvents(svg) {
                     node.r          = node.private._r * e.transform.k;
                   })
                 }
+                svg.node().dispatchEvent(new CustomEvent('simulation-zoomed', {detail: {k: e.transform.k}}));
               })
       )
       .on("dblclick.zoom", null)
@@ -44,6 +46,7 @@ export function initSvgEvents(svg) {
 
                 simulationElements.nodesWrapper.attr("transform", `translate(${nodeG_transform.x}, ${nodeG_transform.y})`);
                 simulationElements.edgesWrapper.attr("transform", `translate(${nodeG_transform.x}, ${nodeG_transform.y})`);
+                svg.node().dispatchEvent(new CustomEvent('simulation-panned', {detail: {x: nodeG_transform.x, y: nodeG_transform.y}}));
               })
               .on('end', (e) => {
                 svg.attr("cursor", "grab");
@@ -78,6 +81,7 @@ export function initSvgEvents(svg) {
         });
         window.spwashi.rects.splice(window.spwashi.rects.indexOf(rect), 1);
         window.spwashi.reinit();
+        svg.node().dispatchEvent(new CustomEvent('simulation-selection', {detail: {nodes: nodes.map(n => n.id)}}));
         rect = null;
         logMainEvent('mouseup:' + e.y + ' ' + e.x);
       });

--- a/src/js/simulation/reinit.js
+++ b/src/js/simulation/reinit.js
@@ -1,5 +1,5 @@
 import { initializeForces } from "./forces";
-import { initSvgProperties, simulationElements } from "./basic";
+import { initSvgProperties, getSimulationElements } from "./basic";
 
 // Dynamically import managers if needed
 async function loadManagers() {
@@ -14,6 +14,7 @@ async function loadManagers() {
 export async function reinit() {
   try {
     // Initialize SVG properties
+    const simulationElements = getSimulationElements();
     initSvgProperties(simulationElements.svg);
 
     window.spwashi.counter = 0;

--- a/src/js/simulation/simulation.js
+++ b/src/js/simulation/simulation.js
@@ -2,8 +2,7 @@ import {NODE_MANAGER}                          from "./nodes/nodes";
 import {forceSimulation}                       from "d3";
 import {getNodeImageHref}                      from "./nodes/attr/href";
 import {getDefaultRects}                       from "./rects/data/default";
-import {initSvgProperties, simulationElements} from "./basic";
-import {initSvgEvents}                         from "./events";
+import {initSvgProperties, getSimulationElements} from "./basic";
 
 function initNodes() {
   window.spwashi.clearCachedNodes = () => {
@@ -27,7 +26,8 @@ export function initSimulationRoot() {
   window.spwashi.reinit = () => console.log('reinit not yet defined')
 
   // try to prevent FOUC
-  initSvgProperties(simulationElements.svg);
+  const { svg } = getSimulationElements();
+  initSvgProperties(svg);
 
   // initialize base simulation data
   initNodes();

--- a/src/js/ui/components/stream-container.js
+++ b/src/js/ui/components/stream-container.js
@@ -12,6 +12,7 @@ import { HonkModeHandler } from '../stream-modes/honk.js';
 import { LoreModeHandler } from '../stream-modes/lore.js';
 import { FocalModeHandler } from '../stream-modes/focal.js';
 import { PassiveModeHandler } from '../stream-modes/passive.js';
+import { registerComponent } from '../util/register-component.js';
 
 const BOON_ITEMS = [];
 const BANE_ITEMS = [];
@@ -426,9 +427,7 @@ class SpwashiStreamContainer extends HTMLElement {
  * Initializes and defines the custom stream container element.
 */
 export function initStreamContainer() {
-  if (!customElements.get('spwashi-stream-container')) {
-    customElements.define('spwashi-stream-container', SpwashiStreamContainer);
-  }
+  registerComponent('spwashi-stream-container', SpwashiStreamContainer);
   document
     .querySelectorAll('spwashi-stream-container')
     .forEach((el) => {

--- a/src/js/util/register-component.js
+++ b/src/js/util/register-component.js
@@ -1,0 +1,5 @@
+export function registerComponent(tagName, componentClass) {
+  if (!customElements.get(tagName)) {
+    customElements.define(tagName, componentClass);
+  }
+}


### PR DESCRIPTION
## Summary
- lazily init simulation SVG nodes
- register custom elements with a helper
- emit zoom, pan and selection events from the simulation

## Testing
- `yarn install` *(fails: RequestError 403)*
- `yarn build` *(fails: package doesn't seem to be present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_b_685339c812b0832ab7a5ad1d76cb1032