### PR TITLE
Fix map filter import path

### DIFF
--- a/src/js/bootstrap/ui.js
+++ b/src/js/bootstrap/ui.js
@@ -20,7 +20,7 @@ export function initUi(mode) {
   initializeDataindexMode();
   initializeStoryMode();
 
-  import("../modes/mapfilter/mode-mapfilter")
+  import("../modes/input/mapfilter/mode-mapfilter")
     .then(({initializeMapFilterMode}) => {
       initializeMapFilterMode();
     })


### PR DESCRIPTION
## Summary
- fix path for dynamic mapfilter import so that initializeMapFilterMode loads

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_685342562118832ab136c3c4b8da87d9