### PR TITLE
Improve CSS variable persistence

### DIFF
--- a/src/js/bootstrap/root.js
+++ b/src/js/bootstrap/root.js
@@ -4,10 +4,12 @@ import {initListeners}      from "./listeners/initListeners";
 import {pushHelpTopics}     from "../modes/input/spw/commands/help";
 import {setDocumentMode}    from "../modes/input";
 import {processSpwInput}    from "../modes/input/spw/process-spw-input";
+import { loadCssVars }      from "../services/style-state";
 
 export function initRoot() {
   initSimulationRoot();
   initRootSession();
+  loadCssVars(['--page-margin-y','--page-margin-x','--focal-x','--focal-y']);
   initCallbacks();
   initListeners();
   window.spwashi.counter   = 0;

--- a/src/js/services/style-state.js
+++ b/src/js/services/style-state.js
@@ -1,0 +1,26 @@
+// services/style-state.js
+
+/**
+ * Update a CSS custom property and optionally persist the value.
+ * The category defaults to 'style.vars'.
+ */
+export function setCssVar(name, value, category = 'style.vars') {
+  document.documentElement.style.setProperty(name, value);
+  if (window.spwashi && window.spwashi.setItem) {
+    window.spwashi.setItem(name, value, category);
+  }
+}
+
+/**
+ * Load persisted CSS variables and apply them to the document.
+ * `names` should be an array of CSS custom property names.
+ */
+export function loadCssVars(names = [], category = 'style.vars') {
+  if (!window.spwashi || !window.spwashi.getItem) return;
+  names.forEach(name => {
+    const stored = window.spwashi.getItem(name, category);
+    if (stored !== undefined) {
+      document.documentElement.style.setProperty(name, stored);
+    }
+  });
+}

--- a/src/js/simulation/basic.js
+++ b/src/js/simulation/basic.js
@@ -1,4 +1,5 @@
 import {select} from "d3";
+import { setCssVar } from "../services/style-state";
 
 let simulationElements = null;
 
@@ -34,7 +35,7 @@ export function initSvgProperties(svg) {
   const pageHeight = document.documentElement.clientHeight;
   const offsetX = (pageWidth - width) / 2;
   const offsetY = (pageHeight - height) / 2;
-  document.documentElement.style.setProperty('--page-margin-y', offsetY + 'px');
-  document.documentElement.style.setProperty('--page-margin-x', offsetX + 'px');
+  setCssVar('--page-margin-y', offsetY + 'px');
+  setCssVar('--page-margin-x', offsetX + 'px');
 }
 

--- a/src/js/ui/components/focal-point.js
+++ b/src/js/ui/components/focal-point.js
@@ -1,5 +1,6 @@
 import { registerComponent } from "../component-registry";
 import { setDocumentMode } from "../../modes/input";
+import { setCssVar } from "../../services/style-state";
 
 let focalPointElement;
 
@@ -114,8 +115,8 @@ export function updateFocalPoint({ x, y }, fix = false) {
         focalPoint.fx = x;
         focalPoint.fy = y;
     }
-    document.documentElement.style.setProperty('--focal-x', `${x}px`);
-    document.documentElement.style.setProperty('--focal-y', `${y}px`);
+    setCssVar('--focal-x', `${x}px`);
+    setCssVar('--focal-y', `${y}px`);
     window.spwashi.setItem('focalPoint', { x, y, fx: x, fy: y }, 'focal.root');
 }
 


### PR DESCRIPTION
## Summary
- create a small service for updating and loading CSS variables
- hook page margin and focal point components into the service
- load persisted CSS vars during bootstrap

## Testing
- `yarn build` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_b_6853413b67ec832a9f4f003836606a72