### PR TITLE
Add accessibility themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,10 @@ Quality assurance checklists live under [docs/qa](docs/qa). See the
 [Ace Editor Styling QA Checklist](docs/qa/ace-editor-style.md) for
 testing the new code editor styles.
 
+## Accessibility
+
+The SCSS includes an optional high‑contrast theme and obeys user
+preferences for reduced motion and light or dark color schemes. Set
+`data-theme="high-contrast"` or `data-theme="dark"` on the `<body>`
+element to override the system preference.
+

--- a/src/styles/scss/core/accessibility.scss
+++ b/src/styles/scss/core/accessibility.scss
@@ -1,0 +1,47 @@
+/* Accessibility and theme enhancements */
+
+/* Focus style for keyboard navigation */
+:focus-visible {
+  outline: 2px solid var(--accent-color-main);
+  outline-offset: 2px;
+}
+
+/* Reduced motion preferences */
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+  }
+}
+
+/* Light theme based on system preference */
+@media (prefers-color-scheme: light) {
+  :root {
+    --html-background: #ffffff;
+    --body-background: #f5f5f5;
+    --form-background: #ffffff;
+    --mainmenu-background: #e5e5e5;
+    --mainmenu-text-color: #222222;
+  }
+}
+
+/* Explicit theme toggles */
+body[data-theme="dark"] {
+  --html-background: #4c1d1d;
+  --body-background: #707070;
+  --form-background: #222222;
+  --mainmenu-background: #222222;
+  --mainmenu-text-color: #f5deb3;
+}
+
+body[data-theme="high-contrast"] {
+  --html-background: #000000;
+  --body-background: #000000;
+  --form-background: #000000;
+  --mainmenu-background: #000000;
+  --mainmenu-text-color: #ffffff;
+  --accent-color-main: #00ffff;
+  --standard-outline: #00ffff;
+  --link-stroke-color: #00ffff;
+}

--- a/src/styles/scss/core/core.scss
+++ b/src/styles/scss/core/core.scss
@@ -3,3 +3,4 @@
 @import "./main-aside";
 @import "./root";
 @import "./svg";
+@import "./accessibility";

--- a/src/styles/scss/main.scss
+++ b/src/styles/scss/main.scss
@@ -2,7 +2,7 @@
 @import "core/core";
 @import "experience/experience";
 @import "interaction/interaction";
-@import "mod../input-modes";
+@import "modes/modes";
 
 /** widgets **/
 @import "widgets/h1";


### PR DESCRIPTION
## Summary
- support light, dark, and high-contrast themes
- obey prefers-reduced-motion and add :focus-visible outline
- document theme toggles in README

## Testing
- `yarn build` *(fails: package missing from lockfile)*

------
https://chatgpt.com/codex/tasks/task_b_685340ba65bc832ab9024da14c33cb43