### PR TITLE
Add routing integration and query param service

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,13 @@ yarn serve
 
 For details on how the initialization pipeline works, see [docs/init-pipeline.md](docs/init-pipeline.md).
 
+### Routing and Query Parameters
+
+The app exposes a lightweight routing integration service that notifies
+listeners when the browser path changes. Query parameter handlers can be
+registered via `services/query-params.js` and will be applied during the
+initial parameter loading step.
+
 ## QA
 
 Quality assurance checklists live under [docs/qa](docs/qa). See the

--- a/docs/init-pipeline.md
+++ b/docs/init-pipeline.md
@@ -36,8 +36,8 @@ a cycle is found during sorting.
 ### Phases
 
 Steps can optionally specify a `phase` that groups them into broad buckets of work.
-Phases are defined in the exported `InitPhase` enum with the values `BOOT`, `UI` and `DEFERRED`.
-The sorter runs all `boot` phase steps before `ui` steps, followed by `deferred` steps.
+Phases are defined in the exported `InitPhase` enum with the values `BOOT`, `UI`, `REFRESH` and `DEFERRED`.
+The sorter runs all `boot` phase steps before `ui` steps, then any `refresh` work and finally `deferred` steps.
 Any step without a known phase is treated as `deferred`.
 
 Phases are useful for keeping lightweight initialization logic (`boot`) separate

--- a/src/js/bootstrap/init-pipeline.js
+++ b/src/js/bootstrap/init-pipeline.js
@@ -1,6 +1,7 @@
 export const InitPhase = {
   BOOT: 'boot',
   UI: 'ui',
+  REFRESH: 'refresh',
   DEFERRED: 'deferred',
 };
 
@@ -39,7 +40,7 @@ export function addInitSteps(steps) {
 
 export function sortSteps(steps) {
   const stepsMap = new Map(steps.map(s => [s.id, s]));
-  const phaseOrder = [InitPhase.BOOT, InitPhase.UI, InitPhase.DEFERRED];
+  const phaseOrder = [InitPhase.BOOT, InitPhase.UI, InitPhase.REFRESH, InitPhase.DEFERRED];
   const phaseRank = phase => {
     const idx = phaseOrder.indexOf(phase);
     return idx === -1 ? phaseOrder.length : idx;

--- a/src/js/bootstrap/init-steps/index.js
+++ b/src/js/bootstrap/init-steps/index.js
@@ -7,6 +7,7 @@ import { loadParameters } from '../bootstrap/parameters/read';
 import { initSvgEvents } from '../simulation/events';
 import { getSimulationElements } from '../simulation/basic';
 import { hydrateUi } from '../bootstrap/hydrate-ui';
+import { initRouter } from '../../services/router';
 
 export const analyticsStep = {
   id: 'analytics',
@@ -53,6 +54,13 @@ export const uiStep = {
   phase: InitPhase.UI,
   dependsOn: [svgStep, parametersStep],
 };
+export const routerStep = {
+  id: 'router',
+  init: initRouter,
+  priority: 7,
+  phase: InitPhase.REFRESH,
+  dependsOn: [uiStep],
+};
 
 export const stepsById = {
   analytics: analyticsStep,
@@ -62,6 +70,7 @@ export const stepsById = {
   queryParams: queryParamsStep,
   svg: svgStep,
   ui: uiStep,
+  router: routerStep,
 };
 
 export const defaultInitSteps = Object.values(stepsById);

--- a/src/js/bootstrap/parameters/read.js
+++ b/src/js/bootstrap/parameters/read.js
@@ -1,7 +1,9 @@
-import {parameterList} from "./_";
+import { parameterList } from "./_";
+import { applyQueryParams } from "../../services/query-params";
 
 export function loadParameters(searchParameters) {
   window.spwashi.featuredIdentity = /\/identity\/([a-zA-Z\d]+)/.exec(window.location.href)?.[1] || searchParameters.get('identity');
   window.spwashi.parameterKey     = `spwashi.parameters#${window.spwashi.featuredIdentity}`;
   parameterList.forEach(fn => fn(searchParameters));
+  applyQueryParams(searchParameters);
 }

--- a/src/js/services/query-params.js
+++ b/src/js/services/query-params.js
@@ -1,0 +1,27 @@
+// services/query-params.js
+// Service for registering query parameter handlers used during hydration.
+
+const handlers = new Map();
+
+export function registerQueryParam(name, handler) {
+  if (!name || typeof handler !== 'function') {
+    throw new Error('registerQueryParam requires a name and handler');
+  }
+  handlers.set(name, handler);
+}
+
+export function applyQueryParams(searchParams) {
+  handlers.forEach((fn, name) => {
+    if (searchParams.has(name)) {
+      try {
+        fn(searchParams.get(name), searchParams);
+      } catch (err) {
+        console.error('query param handler failed', name, err);
+      }
+    }
+  });
+}
+
+export function registeredParamNames() {
+  return [...handlers.keys()];
+}

--- a/src/js/services/router.js
+++ b/src/js/services/router.js
@@ -1,0 +1,32 @@
+// services/router.js
+// Simple routing integration service sensitive to app loading phases.
+// It notifies registered listeners when the browser location changes.
+
+const listeners = new Set();
+
+function handleRouteChange() {
+  const path = window.location.pathname;
+  listeners.forEach(fn => {
+    try {
+      fn(path);
+    } catch (err) {
+      console.error('route listener failed', err);
+    }
+  });
+}
+
+export function initRouter() {
+  window.addEventListener('popstate', handleRouteChange);
+  // emit the initial route
+  handleRouteChange();
+}
+
+export function registerRouteListener(fn) {
+  listeners.add(fn);
+  return () => listeners.delete(fn);
+}
+
+export function clearRouteListeners() {
+  listeners.clear();
+  window.removeEventListener('popstate', handleRouteChange);
+}


### PR DESCRIPTION
## Summary
- introduce `router` integration service
- begin `query-params` registration service
- support `REFRESH` phase in the initialization pipeline
- hook router step into the pipeline
- document new services and phase

## Testing
- `yarn install` *(fails: Bad response 403)*
- `yarn build` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_b_68534653740c832ab750e3ab2355a40a