### PR TITLE
Implement simple UI cache logging

### DIFF
--- a/src/js/services/cache.js
+++ b/src/js/services/cache.js
@@ -1,0 +1,43 @@
+// services/cache.js
+
+export const UI_CACHE_CATEGORY = 'ui.cache';
+
+/**
+ * Cache a value using window.spwashi's localStorage helpers.
+ * Logs the action when debug mode is enabled.
+ */
+export function cacheItem(key, value, category = UI_CACHE_CATEGORY) {
+  if (window.spwashi && window.spwashi.setItem) {
+    window.spwashi.setItem(key, value, category);
+    if (window.spwashi.parameters?.debug) {
+      console.log(`[cache] set ${key} ->`, value);
+    }
+  } else if (window.spwashi?.parameters?.debug) {
+    console.warn(`[cache] unable to set ${key}`);
+  }
+}
+
+/**
+ * Retrieve a cached value.
+ * Logs the result when debug mode is enabled.
+ */
+export function loadCachedItem(key, category = UI_CACHE_CATEGORY) {
+  if (!window.spwashi || !window.spwashi.getItem) return undefined;
+  const value = window.spwashi.getItem(key, category);
+  if (window.spwashi.parameters?.debug) {
+    console.log(`[cache] load ${key} ->`, value);
+  }
+  return value;
+}
+
+/**
+ * Load multiple cached values at once.
+ */
+export function loadCachedItems(keys = [], category = UI_CACHE_CATEGORY) {
+  const out = {};
+  keys.forEach(k => {
+    const v = loadCachedItem(k, category);
+    if (v !== undefined) out[k] = v;
+  });
+  return out;
+}

--- a/src/js/services/style-state.js
+++ b/src/js/services/style-state.js
@@ -4,10 +4,16 @@
  * Update a CSS custom property and optionally persist the value.
  * The category defaults to 'style.vars'.
  */
-export function setCssVar(name, value, category = 'style.vars') {
+import { cacheItem, loadCachedItem } from './cache.js';
+
+export const STYLE_VARS_CATEGORY = 'style.vars';
+
+export function setCssVar(name, value, category = STYLE_VARS_CATEGORY) {
   document.documentElement.style.setProperty(name, value);
   if (window.spwashi && window.spwashi.setItem) {
-    window.spwashi.setItem(name, value, category);
+    cacheItem(name, value, category);
+  } else if (window.spwashi?.parameters?.debug) {
+    console.warn(`[style-state] unable to cache ${name}`);
   }
 }
 
@@ -15,10 +21,10 @@ export function setCssVar(name, value, category = 'style.vars') {
  * Load persisted CSS variables and apply them to the document.
  * `names` should be an array of CSS custom property names.
  */
-export function loadCssVars(names = [], category = 'style.vars') {
+export function loadCssVars(names = [], category = STYLE_VARS_CATEGORY) {
   if (!window.spwashi || !window.spwashi.getItem) return;
   names.forEach(name => {
-    const stored = window.spwashi.getItem(name, category);
+    const stored = loadCachedItem(name, category);
     if (stored !== undefined) {
       document.documentElement.style.setProperty(name, stored);
     }


### PR DESCRIPTION
## Summary
- add a generic caching helper with optional debug logs
- integrate caching helper into CSS variable state management
- extract constants for cache categories

## Testing
- `yarn test` *(fails: This package doesn't seem to be present in your lockfile)*


------
https://chatgpt.com/codex/tasks/task_b_685345077868832a893d38432b98f2e8