### PR TITLE
Expose init phases

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -12,7 +12,7 @@
       app()
     </script>
 </head>
-<body data-mode="nothing" data-interface-depth="standard">
+<body data-mode="nothing" data-interface-depth="standard" data-phase="initial">
 <button id="main-wonder-button">?</button>
 <h1>&lt;concept&gt;</h1>
 <section id="main-stream-container">

--- a/src/js/bootstrap/init-pipeline.js
+++ b/src/js/bootstrap/init-pipeline.js
@@ -81,8 +81,14 @@ export function sortSteps(steps) {
 
 export async function runInitPipeline() {
   const ordered = sortSteps(initSteps);
-  for (const { init } of ordered) {
+  for (const { init, phase } of ordered) {
+    if (phase && document.body) {
+      document.body.dataset.phase = phase;
+    }
     await init();
+  }
+  if (document.body) {
+    document.body.dataset.phase = 'ready';
   }
 }
 

--- a/src/styles/scss/widgets/h1.scss
+++ b/src/styles/scss/widgets/h1.scss
@@ -36,3 +36,15 @@ h1 {
 #h1-input:focus, #h1-input + button:focus {
   outline: thick solid var(--accent-color-main);
 }
+
+body[data-phase="boot"] {
+  h1 {
+    opacity: .5;
+  }
+}
+
+body[data-phase="ui"] {
+  h1 {
+    opacity: 1;
+  }
+}

--- a/src/styles/scss/widgets/wonder-button.scss
+++ b/src/styles/scss/widgets/wonder-button.scss
@@ -14,3 +14,15 @@
   line-height: 1.5rem;
   font-family: monospace;
 }
+
+body[data-phase="boot"] {
+  #main-wonder-button {
+    opacity: .5;
+  }
+}
+
+body[data-phase="ui"] {
+  #main-wonder-button {
+    opacity: 1;
+  }
+}


### PR DESCRIPTION
## Summary
- expose init phase on the body
- update init pipeline so steps update the phase
- begin styling widgets based on init phase

## Testing
- `yarn build` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_b_68534880c4b4832a9f89b69adcb47f5b