### PR TITLE
Improve responsive styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,11 @@ preferences for reduced motion and light or dark color schemes. Set
 `data-theme="high-contrast"` or `data-theme="dark"` on the `<body>`
 element to override the system preference.
 
+## Responsive Design
+
+Viewport specific overrides live under `styles/scss/form-factors`. The
+`style.css` file now contains rules for mobile (`max-width: 600px`),
+tablet (`601px`‑`900px`) and desktop screens. These breakpoints hide or
+resize certain UI elements to keep the interface usable across a range
+of devices.
+

--- a/README.md
+++ b/README.md
@@ -58,9 +58,9 @@ element to override the system preference.
 
 ## Responsive Design
 
-Viewport specific overrides live under `styles/scss/form-factors`. The
-`style.css` file now contains rules for mobile (`max-width: 600px`),
-tablet (`601px`‑`900px`) and desktop screens. These breakpoints hide or
-resize certain UI elements to keep the interface usable across a range
-of devices.
+Viewport specific overrides live under `styles/scss/form-factors`.
+`style.scss` imports separate files for `mobile`, `tablet`, and `desktop`
+rules. Additional tweaks in `orientation.scss` adjust layouts when a
+device switches between portrait and landscape. These breakpoints keep
+the interface usable across a range of devices.
 

--- a/src/index.html
+++ b/src/index.html
@@ -5,7 +5,7 @@
     <link rel="icon" href="/v0.0.1/favicon/16.png">
     <link rel="manifest" href="/manifest.json">
     <link href="styles/scss/main.scss" rel="stylesheet"/>
-    <link href="styles/scss/form-factors/style.css" rel="stylesheet"/>
+    <link href="styles/scss/form-factors/style.scss" rel="stylesheet"/>
     <script type="module">
       import {app} from "./js/main.js";
 

--- a/src/styles/scss/form-factors/desktop.scss
+++ b/src/styles/scss/form-factors/desktop.scss
@@ -1,0 +1,9 @@
+@media (min-width: 901px) {
+    #main-log {
+        display: flex;
+    }
+    #mainmenu-shortcuts button {
+        width: 5rem;
+        height: 5rem;
+    }
+}

--- a/src/styles/scss/form-factors/mobile.scss
+++ b/src/styles/scss/form-factors/mobile.scss
@@ -21,41 +21,11 @@
         width: 4rem;
         height: 4rem;
         font-size: .85rem;
-        padding: .5rem
+        padding: .5rem;
     }
     #spw-parse-field {
         font-size: 1.5rem;
         width: 20rem;
         height: 10rem;
-    }
-}
-
-@media (min-width: 601px) and (max-width: 900px) {
-    #main-log {
-        max-width: 15rem;
-    }
-    #mainmenu-shortcuts button {
-        width: 4rem;
-        height: 4rem;
-    }
-    #reflexes button {
-        width: 5rem;
-        height: 5rem;
-        font-size: 1rem;
-    }
-    #spw-parse-field {
-        font-size: 1.75rem;
-        width: 24rem;
-        height: 12rem;
-    }
-}
-
-@media (min-width: 901px) {
-    #main-log {
-        display: flex;
-    }
-    #mainmenu-shortcuts button {
-        width: 5rem;
-        height: 5rem;
     }
 }

--- a/src/styles/scss/form-factors/orientation.scss
+++ b/src/styles/scss/form-factors/orientation.scss
@@ -1,0 +1,12 @@
+/* Orientation tweaks */
+@media (max-width: 600px) and (orientation: landscape) {
+    #mainmenu-shortcuts ol {
+        flex-direction: row;
+    }
+}
+
+@media (min-width: 601px) and (max-width: 900px) and (orientation: portrait) {
+    #mainmenu-shortcuts ol {
+        flex-direction: column;
+    }
+}

--- a/src/styles/scss/form-factors/style.css
+++ b/src/styles/scss/form-factors/style.css
@@ -1,4 +1,3 @@
-
 @media (max-width: 600px) {
     #main-log {
         display: none;
@@ -28,5 +27,35 @@
         font-size: 1.5rem;
         width: 20rem;
         height: 10rem;
+    }
+}
+
+@media (min-width: 601px) and (max-width: 900px) {
+    #main-log {
+        max-width: 15rem;
+    }
+    #mainmenu-shortcuts button {
+        width: 4rem;
+        height: 4rem;
+    }
+    #reflexes button {
+        width: 5rem;
+        height: 5rem;
+        font-size: 1rem;
+    }
+    #spw-parse-field {
+        font-size: 1.75rem;
+        width: 24rem;
+        height: 12rem;
+    }
+}
+
+@media (min-width: 901px) {
+    #main-log {
+        display: flex;
+    }
+    #mainmenu-shortcuts button {
+        width: 5rem;
+        height: 5rem;
     }
 }

--- a/src/styles/scss/form-factors/style.scss
+++ b/src/styles/scss/form-factors/style.scss
@@ -1,0 +1,4 @@
+@import "mobile";
+@import "tablet";
+@import "desktop";
+@import "orientation";

--- a/src/styles/scss/form-factors/tablet.scss
+++ b/src/styles/scss/form-factors/tablet.scss
@@ -1,0 +1,19 @@
+@media (min-width: 601px) and (max-width: 900px) {
+    #main-log {
+        max-width: 15rem;
+    }
+    #mainmenu-shortcuts button {
+        width: 4rem;
+        height: 4rem;
+    }
+    #reflexes button {
+        width: 5rem;
+        height: 5rem;
+        font-size: 1rem;
+    }
+    #spw-parse-field {
+        font-size: 1.75rem;
+        width: 24rem;
+        height: 12rem;
+    }
+}


### PR DESCRIPTION
## Summary
- add mobile/tablet/desktop breakpoints under `styles/scss/form-factors`
- document form factor overrides in README

## Testing
- `yarn build` *(fails: package missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_b_68534acd2c18832a8e0b58e0c72e45ba