### PR TITLE
Add SCSS for component loading state

### DIFF
--- a/src/styles/scss/main.scss
+++ b/src/styles/scss/main.scss
@@ -10,6 +10,9 @@
 @import "widgets/log";
 @import "widgets/title-md5";
 @import "widgets/wonder-button";
+@import "widgets/main-menu-toggle";
+@import "widgets/simulation-controls";
+@import "widgets/stream-config";
 
 /** vendor **/
 @import "vendor/ace-edit.scss";

--- a/src/styles/scss/widgets/main-menu-toggle.scss
+++ b/src/styles/scss/widgets/main-menu-toggle.scss
@@ -1,0 +1,20 @@
+#main-menu-toggle {
+  position: absolute;
+  top: 0;
+  left: 0;
+  background: #222;
+  color: var(--accent-color-main);
+  border: thin solid var(--standard-outline);
+  padding: 0.5rem 1rem;
+  font-family: var(--font-family);
+}
+
+body[data-phase="boot"] {
+  #main-menu-toggle { opacity: .5; }
+}
+body[data-phase="ui"] {
+  #main-menu-toggle { opacity: 1; }
+}
+[data-interface-depth="minimalism"] {
+  #main-menu-toggle { display: none; }
+}

--- a/src/styles/scss/widgets/simulation-controls.scss
+++ b/src/styles/scss/widgets/simulation-controls.scss
@@ -1,0 +1,28 @@
+#controls {
+  margin-left: 1rem;
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+  & > section {
+    margin-right: 1rem;
+  }
+  label {
+    color: var(--mainmenu-text-color);
+    font-weight: bold;
+  }
+  .button-container {
+    display: flex;
+    flex-direction: column;
+  }
+  button {
+    padding: .5rem;
+    font-family: var(--font-family);
+  }
+}
+body[data-phase="boot"] {
+  #controls { opacity: .5; }
+}
+[data-interface-depth="minimalism"] {
+  #controls { display: none; }
+}

--- a/src/styles/scss/widgets/stream-config.scss
+++ b/src/styles/scss/widgets/stream-config.scss
@@ -1,0 +1,14 @@
+#debug-mode-container fieldset {
+  border: 1px solid var(--accent-color-main);
+  padding: 0.5rem;
+  margin: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+body[data-phase="boot"] {
+  #debug-mode-container fieldset { opacity: .5; }
+}
+[data-interface-depth="minimalism"] {
+  #debug-mode-container fieldset { display: none; }
+}


### PR DESCRIPTION
## Summary
- add SCSS modules for main menu toggle, simulation controls and stream config
- hook new styles into the global SCSS entry
- styles include phase and interface-depth rules

## Testing
- `yarn install`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_b_68534a5c6abc832aa7575488181c039e