### PR TITLE
Extend widget styles for modes and phases

### DIFF
--- a/src/styles/scss/widgets/hotkey-menu.scss
+++ b/src/styles/scss/widgets/hotkey-menu.scss
@@ -96,3 +96,17 @@
 #keystroke-options li:focus, #keystroke-options li:has(button:hover) {
   background: var(--keystroke-options-hover-background);
 }
+
+body[data-phase="boot"] {
+  #hotkey-container,
+  #hotkey-menu-toggle {
+    opacity: .5;
+  }
+}
+
+body[data-phase="ui"] {
+  #hotkey-container,
+  #hotkey-menu-toggle {
+    opacity: 1;
+  }
+}

--- a/src/styles/scss/widgets/log.scss
+++ b/src/styles/scss/widgets/log.scss
@@ -20,3 +20,23 @@
     display: inline-block;
   }
 }
+
+[data-mode=debug] {
+  #main-log {
+    display: flex;
+  }
+}
+
+body[data-phase="boot"] {
+  #main-log,
+  #events-log {
+    opacity: .5;
+  }
+}
+
+body[data-phase="ui"] {
+  #main-log,
+  #events-log {
+    opacity: 1;
+  }
+}

--- a/src/styles/scss/widgets/page-image.scss
+++ b/src/styles/scss/widgets/page-image.scss
@@ -2,9 +2,28 @@
   position: absolute;
   bottom: 0;
   right: 0;
+  display: none;
   img {
     max-width: 20rem;
     max-height: 20rem;
     border: thin solid var(--accent-color-main);
+  }
+}
+
+[data-mode=spw] {
+  #main-image-container {
+    display: block;
+  }
+}
+
+body[data-phase="boot"] {
+  #main-image-container {
+    opacity: .5;
+  }
+}
+
+body[data-phase="ui"] {
+  #main-image-container {
+    opacity: 1;
   }
 }

--- a/src/styles/scss/widgets/title-md5.scss
+++ b/src/styles/scss/widgets/title-md5.scss
@@ -13,3 +13,15 @@ body:not([data-mode=null]) {
     right: var(--page-margin-x);
   }
 }
+
+body[data-phase="boot"] {
+  #title-md5 {
+    opacity: .5;
+  }
+}
+
+body[data-phase="ui"] {
+  #title-md5 {
+    opacity: 1;
+  }
+}


### PR DESCRIPTION
## Summary
- adjust hotkey menu opacity by phase
- show the debug log only in debug mode
- reveal page image container only in spw mode and fade in by phase
- fade MD5 title tag in boot phase

## Testing
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_b_68534bc77afc832a9b669914d5f26efd