### PR TITLE
Refactor simulation data registration

### DIFF
--- a/src/js/services/simulation/index.js
+++ b/src/js/services/simulation/index.js
@@ -3,6 +3,7 @@ import { forceSimulation } from 'd3';
 import { getNodeImageHref } from '../../simulation/nodes/attr/href';
 import { getDefaultRects } from '../../simulation/rects/data/default';
 import { initSvgProperties, getSimulationElements } from '../../simulation/basic';
+import { registerData } from '../../simulation/data';
 
 function initNodes() {
   window.spwashi.clearCachedNodes = () => {
@@ -11,14 +12,23 @@ function initNodes() {
   window.spwashi.getNodeImageHref = getNodeImageHref;
   window.spwashi.getNode = NODE_MANAGER.getNode;
   window.spwashi.nodes = [];
+  const mode  = window.spwashi.parameters.mode;
+  const phase = document.body?.dataset.phase || 'default';
+  registerData('nodes', window.spwashi.nodes, { mode, phase });
 }
 
 function initEdges() {
   window.spwashi.links = [];
+  const mode  = window.spwashi.parameters.mode;
+  const phase = document.body?.dataset.phase || 'default';
+  registerData('links', window.spwashi.links, { mode, phase });
 }
 
 function initRects() {
   window.spwashi.rects = getDefaultRects();
+  const mode  = window.spwashi.parameters.mode;
+  const phase = document.body?.dataset.phase || 'default';
+  registerData('rects', window.spwashi.rects, { mode, phase });
 }
 
 export function initSimulationRoot() {
@@ -32,6 +42,10 @@ export function initSimulationRoot() {
   initRects();
 
   window.spwashi.simulation = forceSimulation();
+  registerData('simulation', window.spwashi.simulation, {
+    mode:  window.spwashi.parameters.mode,
+    phase: document.body?.dataset.phase || 'default',
+  });
 
   import('../../simulation/reinit').then(({ reinit }) => {
     window.spwashi.reinit = reinit;

--- a/src/js/services/simulation/index.js
+++ b/src/js/services/simulation/index.js
@@ -3,7 +3,7 @@ import { forceSimulation } from 'd3';
 import { getNodeImageHref } from '../../simulation/nodes/attr/href';
 import { getDefaultRects } from '../../simulation/rects/data/default';
 import { initSvgProperties, getSimulationElements } from '../../simulation/basic';
-import { registerData } from '../../simulation/data';
+import { registerSlice } from '../../simulation/data';
 
 function initNodes() {
   window.spwashi.clearCachedNodes = () => {
@@ -14,21 +14,42 @@ function initNodes() {
   window.spwashi.nodes = [];
   const mode  = window.spwashi.parameters.mode;
   const phase = document.body?.dataset.phase || 'default';
-  registerData('nodes', window.spwashi.nodes, { mode, phase });
+  const aggregator = window.spwashi.parameters.dataAggregator || 'array';
+  const slice = registerSlice('nodes', {
+    initialData: window.spwashi.nodes,
+    mode,
+    phase,
+    aggregator,
+  });
+  window.spwashi.nodesSlice = slice;
 }
 
 function initEdges() {
   window.spwashi.links = [];
   const mode  = window.spwashi.parameters.mode;
   const phase = document.body?.dataset.phase || 'default';
-  registerData('links', window.spwashi.links, { mode, phase });
+  const aggregator = window.spwashi.parameters.dataAggregator || 'array';
+  const slice = registerSlice('links', {
+    initialData: window.spwashi.links,
+    mode,
+    phase,
+    aggregator,
+  });
+  window.spwashi.linksSlice = slice;
 }
 
 function initRects() {
   window.spwashi.rects = getDefaultRects();
   const mode  = window.spwashi.parameters.mode;
   const phase = document.body?.dataset.phase || 'default';
-  registerData('rects', window.spwashi.rects, { mode, phase });
+  const aggregator = window.spwashi.parameters.dataAggregator || 'array';
+  const slice = registerSlice('rects', {
+    initialData: window.spwashi.rects,
+    mode,
+    phase,
+    aggregator,
+  });
+  window.spwashi.rectsSlice = slice;
 }
 
 export function initSimulationRoot() {
@@ -42,9 +63,11 @@ export function initSimulationRoot() {
   initRects();
 
   window.spwashi.simulation = forceSimulation();
-  registerData('simulation', window.spwashi.simulation, {
+  registerSlice('simulation', {
+    initialData: window.spwashi.simulation,
     mode:  window.spwashi.parameters.mode,
     phase: document.body?.dataset.phase || 'default',
+    aggregator: 'array',
   });
 
   import('../../simulation/reinit').then(({ reinit }) => {

--- a/src/js/simulation/data/index.js
+++ b/src/js/simulation/data/index.js
@@ -1,0 +1,1 @@
+export { registerData, getData, toggleDisplay, isDisplayEnabled, clearData } from './registry';

--- a/src/js/simulation/data/index.js
+++ b/src/js/simulation/data/index.js
@@ -1,1 +1,10 @@
-export { registerData, getData, toggleDisplay, isDisplayEnabled, clearData } from './registry';
+export {
+  registerSlice,
+  getSlice,
+  getData,
+  toggleDisplay,
+  isDisplayEnabled,
+  clearData
+} from './registry';
+
+export { createDataSlice, createArraySlice, getAggregator } from './slice';

--- a/src/js/simulation/data/registry.js
+++ b/src/js/simulation/data/registry.js
@@ -1,6 +1,4 @@
-// registry.js
-// Centralized registry for simulation data keyed by app mode and phase.
-// Allows optional display control and memory management for snapshots.
+import { createDataSlice } from './slice.js';
 
 const registry = new Map();
 
@@ -8,14 +6,20 @@ function makeKey(key, mode = 'default', phase = 'default') {
   return `${mode}:${phase}:${key}`;
 }
 
-export function registerData(key, data, { mode = 'default', phase = 'default', display = true } = {}) {
+export function registerSlice(key, { initialData = [], slice, aggregator = 'array', mode = 'default', phase = 'default', display = true } = {}) {
   const regKey = makeKey(key, mode, phase);
-  registry.set(regKey, { data, display });
+  const finalSlice = slice || createDataSlice(initialData, aggregator);
+  registry.set(regKey, { slice: finalSlice, display });
+  return finalSlice;
 }
 
-export function getData(key, { mode = 'default', phase = 'default' } = {}) {
+export function getSlice(key, { mode = 'default', phase = 'default' } = {}) {
   const regKey = makeKey(key, mode, phase);
-  return registry.get(regKey)?.data;
+  return registry.get(regKey)?.slice;
+}
+
+export function getData(key, opts = {}) {
+  return getSlice(key, opts)?.get();
 }
 
 export function toggleDisplay(key, { mode = 'default', phase = 'default', display } = {}) {
@@ -31,6 +35,7 @@ export function isDisplayEnabled(key, { mode = 'default', phase = 'default' } = 
   return registry.get(regKey)?.display ?? false;
 }
 
-export function clearData(key, { mode = 'default', phase = 'default' } = {}) {
-  registry.delete(makeKey(key, mode, phase));
+export function clearData(key, opts = {}) {
+  const slice = getSlice(key, opts);
+  slice?.clear();
 }

--- a/src/js/simulation/data/registry.js
+++ b/src/js/simulation/data/registry.js
@@ -1,0 +1,36 @@
+// registry.js
+// Centralized registry for simulation data keyed by app mode and phase.
+// Allows optional display control and memory management for snapshots.
+
+const registry = new Map();
+
+function makeKey(key, mode = 'default', phase = 'default') {
+  return `${mode}:${phase}:${key}`;
+}
+
+export function registerData(key, data, { mode = 'default', phase = 'default', display = true } = {}) {
+  const regKey = makeKey(key, mode, phase);
+  registry.set(regKey, { data, display });
+}
+
+export function getData(key, { mode = 'default', phase = 'default' } = {}) {
+  const regKey = makeKey(key, mode, phase);
+  return registry.get(regKey)?.data;
+}
+
+export function toggleDisplay(key, { mode = 'default', phase = 'default', display } = {}) {
+  const regKey = makeKey(key, mode, phase);
+  const entry = registry.get(regKey);
+  if (entry) {
+    entry.display = typeof display === 'boolean' ? display : !entry.display;
+  }
+}
+
+export function isDisplayEnabled(key, { mode = 'default', phase = 'default' } = {}) {
+  const regKey = makeKey(key, mode, phase);
+  return registry.get(regKey)?.display ?? false;
+}
+
+export function clearData(key, { mode = 'default', phase = 'default' } = {}) {
+  registry.delete(makeKey(key, mode, phase));
+}

--- a/src/js/simulation/data/slice.js
+++ b/src/js/simulation/data/slice.js
@@ -1,0 +1,35 @@
+export function createArraySlice(initialData = []) {
+  const data = Array.from(initialData);
+  return {
+    get: () => data,
+    set(newData = []) {
+      data.length = 0;
+      data.push(...newData);
+    },
+    push(...items) {
+      data.push(...items);
+    },
+    clear() {
+      data.length = 0;
+    },
+    *stream() {
+      for (const item of data) {
+        yield item;
+      }
+    },
+    [Symbol.iterator]: function* () {
+      yield* data;
+    }
+  };
+}
+
+const aggregatorMap = { array: createArraySlice };
+
+export function getAggregator(name = 'array') {
+  return aggregatorMap[name] || createArraySlice;
+}
+
+export function createDataSlice(initialData = [], aggregator = 'array') {
+  const create = typeof aggregator === 'string' ? getAggregator(aggregator) : aggregator;
+  return create(initialData);
+}

--- a/src/js/simulation/edges/data/pushLink.js
+++ b/src/js/simulation/edges/data/pushLink.js
@@ -1,9 +1,10 @@
-import { registerData } from "../../data/registry";
+import { getSlice } from "../../data";
 
 export function pushLink(links, ...newLinks) {
   links.push(...newLinks);
   const mode  = window.spwashi?.parameters?.mode || 'default';
   const phase = document.body?.dataset?.phase || 'default';
-  registerData('links', links, { mode, phase });
+  const slice = getSlice('links', { mode, phase });
+  slice?.push(...newLinks);
   return links;
 }

--- a/src/js/simulation/edges/data/pushLink.js
+++ b/src/js/simulation/edges/data/pushLink.js
@@ -1,4 +1,9 @@
+import { registerData } from "../../data/registry";
+
 export function pushLink(links, ...newLinks) {
   links.push(...newLinks);
+  const mode  = window.spwashi?.parameters?.mode || 'default';
+  const phase = document.body?.dataset?.phase || 'default';
+  registerData('links', links, { mode, phase });
   return links;
 }

--- a/src/js/simulation/edges/data/set.js
+++ b/src/js/simulation/edges/data/set.js
@@ -1,13 +1,24 @@
+import { registerData } from "../../data/registry";
+
 export function removeAllLinks() {
   window.spwashi.links.length = 0;
+  const mode  = window.spwashi?.parameters?.mode || 'default';
+  const phase = document.body?.dataset?.phase || 'default';
+  registerData('links', window.spwashi.links, { mode, phase });
 }
 
 export function removeNodeEdges(d) {
   window.spwashi.links = window.spwashi.links.filter(link => {
     return link.source !== d && link.target !== d;
   });
+  const mode  = window.spwashi?.parameters?.mode || 'default';
+  const phase = document.body?.dataset?.phase || 'default';
+  registerData('links', window.spwashi.links, { mode, phase });
 }
 
 export function removeObsoleteEdges(nodes) {
   window.spwashi.links = window.spwashi.links.filter(link => nodes.includes(link.source) && nodes.includes(link.target));
+  const mode  = window.spwashi?.parameters?.mode || 'default';
+  const phase = document.body?.dataset?.phase || 'default';
+  registerData('links', window.spwashi.links, { mode, phase });
 }

--- a/src/js/simulation/edges/data/set.js
+++ b/src/js/simulation/edges/data/set.js
@@ -1,10 +1,11 @@
-import { registerData } from "../../data/registry";
+import { getSlice } from "../../data";
 
 export function removeAllLinks() {
   window.spwashi.links.length = 0;
   const mode  = window.spwashi?.parameters?.mode || 'default';
   const phase = document.body?.dataset?.phase || 'default';
-  registerData('links', window.spwashi.links, { mode, phase });
+  const slice = getSlice('links', { mode, phase });
+  slice?.clear();
 }
 
 export function removeNodeEdges(d) {
@@ -13,12 +14,14 @@ export function removeNodeEdges(d) {
   });
   const mode  = window.spwashi?.parameters?.mode || 'default';
   const phase = document.body?.dataset?.phase || 'default';
-  registerData('links', window.spwashi.links, { mode, phase });
+  const slice = getSlice('links', { mode, phase });
+  slice?.set(window.spwashi.links);
 }
 
 export function removeObsoleteEdges(nodes) {
   window.spwashi.links = window.spwashi.links.filter(link => nodes.includes(link.source) && nodes.includes(link.target));
   const mode  = window.spwashi?.parameters?.mode || 'default';
   const phase = document.body?.dataset?.phase || 'default';
-  registerData('links', window.spwashi.links, { mode, phase });
+  const slice = getSlice('links', { mode, phase });
+  slice?.set(window.spwashi.links);
 }

--- a/src/js/simulation/nodes/data/set.js
+++ b/src/js/simulation/nodes/data/set.js
@@ -1,7 +1,7 @@
 /**
  * Safely retrieve the global `spwashi` object, initializing if not present.
  */
-import { registerData } from "../../data/registry";
+import { getSlice } from "../../data";
 
 function getSpwashiGlobal() {
   if (!window.spwashi) {
@@ -18,7 +18,8 @@ function setSpwashiNodes(nodes) {
   getSpwashiGlobal().nodes = nodes;
   const mode  = window.spwashi?.parameters?.mode || 'default';
   const phase = document.body?.dataset?.phase || 'default';
-  registerData('nodes', nodes, { mode, phase });
+  const slice = getSlice('nodes', { mode, phase });
+  slice?.set(nodes);
 }
 
 function getSpwashiLinks() {
@@ -27,6 +28,10 @@ function getSpwashiLinks() {
 
 function setSpwashiLinks(links) {
   getSpwashiGlobal().links = links;
+  const mode  = window.spwashi?.parameters?.mode || 'default';
+  const phase = document.body?.dataset?.phase || 'default';
+  const slice = getSlice('links', { mode, phase });
+  slice?.set(links);
 }
 
 /**

--- a/src/js/simulation/nodes/data/set.js
+++ b/src/js/simulation/nodes/data/set.js
@@ -1,6 +1,8 @@
 /**
  * Safely retrieve the global `spwashi` object, initializing if not present.
  */
+import { registerData } from "../../data/registry";
+
 function getSpwashiGlobal() {
   if (!window.spwashi) {
     window.spwashi = { nodes: [], links: [] };
@@ -14,6 +16,9 @@ function getSpwashiNodes() {
 
 function setSpwashiNodes(nodes) {
   getSpwashiGlobal().nodes = nodes;
+  const mode  = window.spwashi?.parameters?.mode || 'default';
+  const phase = document.body?.dataset?.phase || 'default';
+  registerData('nodes', nodes, { mode, phase });
 }
 
 function getSpwashiLinks() {

--- a/src/js/simulation/rects/data/default.js
+++ b/src/js/simulation/rects/data/default.js
@@ -1,5 +1,7 @@
+import { registerData } from "../../data/registry";
+
 export function getDefaultRects() {
-  return [
+  const rects = [
     {
       title: 'Counter',
       x:     0,
@@ -66,4 +68,8 @@ export function getDefaultRects() {
     r.y      = i * 20;
     return r;
   });
+  const mode  = window.spwashi?.parameters?.mode || 'default';
+  const phase = document.body?.dataset?.phase || 'default';
+  registerData('rects', rects, { mode, phase });
+  return rects;
 }

--- a/src/js/simulation/rects/data/default.js
+++ b/src/js/simulation/rects/data/default.js
@@ -1,4 +1,4 @@
-import { registerData } from "../../data/registry";
+import { getSlice } from "../../data";
 
 export function getDefaultRects() {
   const rects = [
@@ -70,6 +70,7 @@ export function getDefaultRects() {
   });
   const mode  = window.spwashi?.parameters?.mode || 'default';
   const phase = document.body?.dataset?.phase || 'default';
-  registerData('rects', rects, { mode, phase });
+  const slice = getSlice('rects', { mode, phase });
+  slice?.set(rects);
   return rects;
 }

--- a/src/js/ui/components/simulation/links.js
+++ b/src/js/ui/components/simulation/links.js
@@ -1,7 +1,7 @@
 import { EDGE_MANAGER } from '../../../simulation/edges/edges';
 import { getSimulationElements } from '../../../simulation/basic';
 import { registerComponent } from '../../component-registry';
-import { isDisplayEnabled } from '../../../simulation/data';
+import { isDisplayEnabled, getData } from '../../../simulation/data';
 
 export function updateSimulationLinks(links) {
   const { wrapper } = getSimulationElements();
@@ -13,7 +13,10 @@ export function updateSimulationLinks(links) {
 }
 
 export function initSimulationLinks() {
-  updateSimulationLinks(window.spwashi.links || []);
+  const mode  = window.spwashi.parameters.mode;
+  const phase = document.body?.dataset.phase || 'default';
+  const links = getData('links', { mode, phase }) || [];
+  updateSimulationLinks(links);
 }
 
 export const simulationLinks = { init: initSimulationLinks, update: updateSimulationLinks };

--- a/src/js/ui/components/simulation/links.js
+++ b/src/js/ui/components/simulation/links.js
@@ -1,10 +1,15 @@
 import { EDGE_MANAGER } from '../../../simulation/edges/edges';
 import { getSimulationElements } from '../../../simulation/basic';
 import { registerComponent } from '../../component-registry';
+import { isDisplayEnabled } from '../../../simulation/data';
 
 export function updateSimulationLinks(links) {
   const { wrapper } = getSimulationElements();
-  EDGE_MANAGER.updateLinks(wrapper, links);
+  const mode  = window.spwashi.parameters.mode;
+  const phase = document.body?.dataset.phase || 'default';
+  if (isDisplayEnabled('links', { mode, phase })) {
+    EDGE_MANAGER.updateLinks(wrapper, links);
+  }
 }
 
 export function initSimulationLinks() {

--- a/src/js/ui/components/simulation/nodes.js
+++ b/src/js/ui/components/simulation/nodes.js
@@ -1,10 +1,15 @@
 import { NODE_MANAGER } from '../../../simulation/nodes/nodes';
 import { getSimulationElements } from '../../../simulation/basic';
 import { registerComponent } from '../../component-registry';
+import { isDisplayEnabled } from '../../../simulation/data';
 
 export function updateSimulationNodes(nodes) {
   const { wrapper } = getSimulationElements();
-  NODE_MANAGER.updateNodes(wrapper, nodes);
+  const mode  = window.spwashi.parameters.mode;
+  const phase = document.body?.dataset.phase || 'default';
+  if (isDisplayEnabled('nodes', { mode, phase })) {
+    NODE_MANAGER.updateNodes(wrapper, nodes);
+  }
 }
 
 export function initSimulationNodes() {

--- a/src/js/ui/components/simulation/nodes.js
+++ b/src/js/ui/components/simulation/nodes.js
@@ -1,7 +1,7 @@
 import { NODE_MANAGER } from '../../../simulation/nodes/nodes';
 import { getSimulationElements } from '../../../simulation/basic';
 import { registerComponent } from '../../component-registry';
-import { isDisplayEnabled } from '../../../simulation/data';
+import { isDisplayEnabled, getData } from '../../../simulation/data';
 
 export function updateSimulationNodes(nodes) {
   const { wrapper } = getSimulationElements();
@@ -13,7 +13,10 @@ export function updateSimulationNodes(nodes) {
 }
 
 export function initSimulationNodes() {
-  updateSimulationNodes(window.spwashi.nodes || []);
+  const mode  = window.spwashi.parameters.mode;
+  const phase = document.body?.dataset.phase || 'default';
+  const nodes = getData('nodes', { mode, phase }) || [];
+  updateSimulationNodes(nodes);
 }
 
 export const simulationNodes = { init: initSimulationNodes, update: updateSimulationNodes };

--- a/src/js/ui/components/simulation/rects.js
+++ b/src/js/ui/components/simulation/rects.js
@@ -1,10 +1,15 @@
 import { RECT_MANAGER } from '../../../simulation/rects/rects';
 import { getSimulationElements } from '../../../simulation/basic';
 import { registerComponent } from '../../component-registry';
+import { isDisplayEnabled } from '../../../simulation/data';
 
 export function updateSimulationRects(rects) {
   const { wrapper } = getSimulationElements();
-  RECT_MANAGER.updateRects(wrapper, rects);
+  const mode  = window.spwashi.parameters.mode;
+  const phase = document.body?.dataset.phase || 'default';
+  if (isDisplayEnabled('rects', { mode, phase })) {
+    RECT_MANAGER.updateRects(wrapper, rects);
+  }
 }
 
 export function initSimulationRects() {

--- a/src/js/ui/components/simulation/rects.js
+++ b/src/js/ui/components/simulation/rects.js
@@ -1,7 +1,7 @@
 import { RECT_MANAGER } from '../../../simulation/rects/rects';
 import { getSimulationElements } from '../../../simulation/basic';
 import { registerComponent } from '../../component-registry';
-import { isDisplayEnabled } from '../../../simulation/data';
+import { isDisplayEnabled, getData } from '../../../simulation/data';
 
 export function updateSimulationRects(rects) {
   const { wrapper } = getSimulationElements();
@@ -13,7 +13,10 @@ export function updateSimulationRects(rects) {
 }
 
 export function initSimulationRects() {
-  updateSimulationRects(window.spwashi.rects || []);
+  const mode  = window.spwashi.parameters.mode;
+  const phase = document.body?.dataset.phase || 'default';
+  const rects = getData('rects', { mode, phase }) || [];
+  updateSimulationRects(rects);
 }
 
 export const simulationRects = { init: initSimulationRects, update: updateSimulationRects };


### PR DESCRIPTION
## Summary
- add data registry for mode/phase aware data storage
- register nodes, links, rects, and simulation objects
- expose display checks in UI components

## Testing
- `yarn test` *(fails: couldn't find script)*
- `yarn build` *(fails: sass syntax error)*

------
https://chatgpt.com/codex/tasks/task_b_6853529f64b4832a8869bf952adf8264