### PR TITLE
Add meta registry for slice data

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ yarn serve
 ## Initialization
 
 For details on how the initialization pipeline works, see [docs/init-pipeline.md](docs/init-pipeline.md).
+Metadata about registered data slices lives in [docs/api/data-meta.md](docs/api/data-meta.md).
 
 ### Routing and Query Parameters
 

--- a/docs/api/data-meta.md
+++ b/docs/api/data-meta.md
@@ -1,0 +1,14 @@
+# Data Meta Registry
+
+Slices registered via `registerSlice` now expose metadata describing the mode and phase used to store the slice.
+
+```javascript
+import { registerSlice, getMeta } from '../src/js/simulation/data';
+
+registerSlice('nodes', { mode: 'spw', phase: 'boot' });
+
+const meta = getMeta('nodes', { mode: 'spw', phase: 'boot' });
+// meta = { query: { mode: 'spw', phase: 'boot' }, data: <slice> }
+```
+
+The `query` object mirrors the `{ mode, phase }` parameters used during registration. The `data` field references the slice instance containing the dataset.

--- a/src/js/simulation/data/index.js
+++ b/src/js/simulation/data/index.js
@@ -4,7 +4,8 @@ export {
   getData,
   toggleDisplay,
   isDisplayEnabled,
-  clearData
+  clearData,
+  getMeta
 } from './registry';
 
 export { createDataSlice, createArraySlice, getAggregator } from './slice';

--- a/src/js/simulation/data/registry.js
+++ b/src/js/simulation/data/registry.js
@@ -1,6 +1,7 @@
 import { createDataSlice } from './slice.js';
 
 const registry = new Map();
+const meta = new Map();
 
 function makeKey(key, mode = 'default', phase = 'default') {
   return `${mode}:${phase}:${key}`;
@@ -10,6 +11,7 @@ export function registerSlice(key, { initialData = [], slice, aggregator = 'arra
   const regKey = makeKey(key, mode, phase);
   const finalSlice = slice || createDataSlice(initialData, aggregator);
   registry.set(regKey, { slice: finalSlice, display });
+  meta.set(regKey, { query: { mode, phase }, data: finalSlice });
   return finalSlice;
 }
 
@@ -38,4 +40,9 @@ export function isDisplayEnabled(key, { mode = 'default', phase = 'default' } = 
 export function clearData(key, opts = {}) {
   const slice = getSlice(key, opts);
   slice?.clear();
+}
+
+export function getMeta(key, { mode = 'default', phase = 'default' } = {}) {
+  const regKey = makeKey(key, mode, phase);
+  return meta.get(regKey);
 }


### PR DESCRIPTION
## Summary
- track slice registration info in a new meta map
- expose `getMeta` through the data module
- document the new meta registry
- mention docs in README

## Testing
- `yarn build` *(fails: expected `=` in ui-feedback.scss)*

------
https://chatgpt.com/codex/tasks/task_b_685359044bac832a816b43bc47c51b0a