### PR TITLE
Refactor simulation modules

### DIFF
--- a/src/js/modes/input/spw/commands/forces.js
+++ b/src/js/modes/input/spw/commands/forces.js
@@ -1,4 +1,4 @@
-import {initializeForces} from "../../../../simulation/forces";
+import { initializeForces } from "../../../../simulation/physics";
 
 export function runForcesCommand(sideEffects) {
   initializeForces();

--- a/src/js/services/simulation/index.js
+++ b/src/js/services/simulation/index.js
@@ -3,7 +3,7 @@ import { forceSimulation } from 'd3';
 import { getNodeImageHref } from '../../simulation/nodes/attr/href';
 import { getDefaultRects } from '../../simulation/rects/data/default';
 import { initSvgProperties, getSimulationElements } from '../../simulation/basic';
-import { registerSlice } from '../../simulation/data';
+import DataManager from '../../simulation/data';
 
 function initNodes() {
   window.spwashi.clearCachedNodes = () => {
@@ -15,7 +15,7 @@ function initNodes() {
   const mode  = window.spwashi.parameters.mode;
   const phase = document.body?.dataset.phase || 'default';
   const aggregator = window.spwashi.parameters.dataAggregator || 'array';
-  const slice = registerSlice('nodes', {
+  const slice = DataManager.registerSlice('nodes', {
     initialData: window.spwashi.nodes,
     mode,
     phase,
@@ -29,7 +29,7 @@ function initEdges() {
   const mode  = window.spwashi.parameters.mode;
   const phase = document.body?.dataset.phase || 'default';
   const aggregator = window.spwashi.parameters.dataAggregator || 'array';
-  const slice = registerSlice('links', {
+  const slice = DataManager.registerSlice('links', {
     initialData: window.spwashi.links,
     mode,
     phase,
@@ -43,7 +43,7 @@ function initRects() {
   const mode  = window.spwashi.parameters.mode;
   const phase = document.body?.dataset.phase || 'default';
   const aggregator = window.spwashi.parameters.dataAggregator || 'array';
-  const slice = registerSlice('rects', {
+  const slice = DataManager.registerSlice('rects', {
     initialData: window.spwashi.rects,
     mode,
     phase,
@@ -63,7 +63,7 @@ export function initSimulationRoot() {
   initRects();
 
   window.spwashi.simulation = forceSimulation();
-  registerSlice('simulation', {
+  DataManager.registerSlice('simulation', {
     initialData: window.spwashi.simulation,
     mode:  window.spwashi.parameters.mode,
     phase: document.body?.dataset.phase || 'default',

--- a/src/js/simulation/active-forces.js
+++ b/src/js/simulation/active-forces.js
@@ -1,13 +1,13 @@
-import { enableForce, disableForce, isForceEnabled } from './force-registry';
+import Physics from './physics';
 
 // Toggle the status of a specific force registered in the force registry.
 export function toggleForce(forceName) {
-  if (isForceEnabled(forceName)) {
-    disableForce(forceName);
+  if (Physics.isForceEnabled(forceName)) {
+    Physics.disableForce(forceName);
   } else {
-    enableForce(forceName);
+    Physics.enableForce(forceName);
   }
-  console.log(`${forceName} force is now ${isForceEnabled(forceName) ? 'enabled' : 'disabled'}.`);
+  console.log(`${forceName} force is now ${Physics.isForceEnabled(forceName) ? 'enabled' : 'disabled'}.`);
 }
 
-export { isForceEnabled } from './force-registry';
+export const { isForceEnabled } = Physics;

--- a/src/js/simulation/data/index.js
+++ b/src/js/simulation/data/index.js
@@ -1,11 +1,29 @@
-export {
+import * as registry from './registry';
+import { createDataSlice, createArraySlice, getAggregator } from './slice';
+
+export const DataManager = {
+  registerSlice: registry.registerSlice,
+  getSlice: registry.getSlice,
+  getData: registry.getData,
+  toggleDisplay: registry.toggleDisplay,
+  isDisplayEnabled: registry.isDisplayEnabled,
+  clearData: registry.clearData,
+  getMeta: registry.getMeta,
+  createDataSlice,
+  createArraySlice,
+  getAggregator,
+};
+
+export const {
   registerSlice,
   getSlice,
   getData,
   toggleDisplay,
   isDisplayEnabled,
   clearData,
-  getMeta
-} from './registry';
+  getMeta,
+} = registry;
 
 export { createDataSlice, createArraySlice, getAggregator } from './slice';
+
+export default DataManager;

--- a/src/js/simulation/physics/index.js
+++ b/src/js/simulation/physics/index.js
@@ -1,0 +1,35 @@
+import {
+  registerForce,
+  enableForce,
+  disableForce,
+  isForceEnabled,
+  updateForceOptions,
+  forceNames,
+  applyRegisteredForces
+} from '../force-registry';
+
+import { initializeForces } from '../forces';
+
+export const Physics = {
+  registerForce,
+  enableForce,
+  disableForce,
+  isForceEnabled,
+  updateForceOptions,
+  forceNames,
+  applyForces: applyRegisteredForces,
+  initialize: initializeForces,
+};
+
+export {
+  registerForce,
+  enableForce,
+  disableForce,
+  isForceEnabled,
+  updateForceOptions,
+  forceNames,
+  applyRegisteredForces,
+  initializeForces,
+};
+
+export default Physics;

--- a/src/js/simulation/reinit.js
+++ b/src/js/simulation/reinit.js
@@ -1,8 +1,10 @@
-import { initializeForces } from "./forces";
+import { initializeForces } from "./physics";
 import { initSvgProperties, getSimulationElements } from "./basic";
-import { updateSimulationLinks } from "../ui/components/simulation/links";
-import { updateSimulationNodes } from "../ui/components/simulation/nodes";
-import { updateSimulationRects } from "../ui/components/simulation/rects";
+import {
+  updateSimulationLinks,
+  updateSimulationNodes,
+  updateSimulationRects,
+} from "../ui/components/simulation";
 
 // Dynamically import managers if needed
 async function loadManagers() {

--- a/src/js/ui/components/simulation/index.js
+++ b/src/js/ui/components/simulation/index.js
@@ -1,0 +1,14 @@
+export { simulationLinks, initSimulationLinks, updateSimulationLinks } from './links';
+export { simulationNodes, initSimulationNodes, updateSimulationNodes } from './nodes';
+export { simulationRects, initSimulationRects, updateSimulationRects } from './rects';
+
+export const SimulationUI = {
+  initLinks: initSimulationLinks,
+  initNodes: initSimulationNodes,
+  initRects: initSimulationRects,
+  updateLinks: updateSimulationLinks,
+  updateNodes: updateSimulationNodes,
+  updateRects: updateSimulationRects,
+};
+
+export default SimulationUI;

--- a/src/js/ui/components/simulation/links.js
+++ b/src/js/ui/components/simulation/links.js
@@ -1,13 +1,13 @@
 import { EDGE_MANAGER } from '../../../simulation/edges/edges';
 import { getSimulationElements } from '../../../simulation/basic';
 import { registerComponent } from '../../component-registry';
-import { isDisplayEnabled, getData } from '../../../simulation/data';
+import DataManager from '../../../simulation/data';
 
 export function updateSimulationLinks(links) {
   const { wrapper } = getSimulationElements();
   const mode  = window.spwashi.parameters.mode;
   const phase = document.body?.dataset.phase || 'default';
-  if (isDisplayEnabled('links', { mode, phase })) {
+  if (DataManager.isDisplayEnabled('links', { mode, phase })) {
     EDGE_MANAGER.updateLinks(wrapper, links);
   }
 }
@@ -15,7 +15,7 @@ export function updateSimulationLinks(links) {
 export function initSimulationLinks() {
   const mode  = window.spwashi.parameters.mode;
   const phase = document.body?.dataset.phase || 'default';
-  const links = getData('links', { mode, phase }) || [];
+  const links = DataManager.getData('links', { mode, phase }) || [];
   updateSimulationLinks(links);
 }
 

--- a/src/js/ui/components/simulation/nodes.js
+++ b/src/js/ui/components/simulation/nodes.js
@@ -1,13 +1,13 @@
 import { NODE_MANAGER } from '../../../simulation/nodes/nodes';
 import { getSimulationElements } from '../../../simulation/basic';
 import { registerComponent } from '../../component-registry';
-import { isDisplayEnabled, getData } from '../../../simulation/data';
+import DataManager from '../../../simulation/data';
 
 export function updateSimulationNodes(nodes) {
   const { wrapper } = getSimulationElements();
   const mode  = window.spwashi.parameters.mode;
   const phase = document.body?.dataset.phase || 'default';
-  if (isDisplayEnabled('nodes', { mode, phase })) {
+  if (DataManager.isDisplayEnabled('nodes', { mode, phase })) {
     NODE_MANAGER.updateNodes(wrapper, nodes);
   }
 }
@@ -15,7 +15,7 @@ export function updateSimulationNodes(nodes) {
 export function initSimulationNodes() {
   const mode  = window.spwashi.parameters.mode;
   const phase = document.body?.dataset.phase || 'default';
-  const nodes = getData('nodes', { mode, phase }) || [];
+  const nodes = DataManager.getData('nodes', { mode, phase }) || [];
   updateSimulationNodes(nodes);
 }
 

--- a/src/js/ui/components/simulation/rects.js
+++ b/src/js/ui/components/simulation/rects.js
@@ -1,13 +1,13 @@
 import { RECT_MANAGER } from '../../../simulation/rects/rects';
 import { getSimulationElements } from '../../../simulation/basic';
 import { registerComponent } from '../../component-registry';
-import { isDisplayEnabled, getData } from '../../../simulation/data';
+import DataManager from '../../../simulation/data';
 
 export function updateSimulationRects(rects) {
   const { wrapper } = getSimulationElements();
   const mode  = window.spwashi.parameters.mode;
   const phase = document.body?.dataset.phase || 'default';
-  if (isDisplayEnabled('rects', { mode, phase })) {
+  if (DataManager.isDisplayEnabled('rects', { mode, phase })) {
     RECT_MANAGER.updateRects(wrapper, rects);
   }
 }
@@ -15,7 +15,7 @@ export function updateSimulationRects(rects) {
 export function initSimulationRects() {
   const mode  = window.spwashi.parameters.mode;
   const phase = document.body?.dataset.phase || 'default';
-  const rects = getData('rects', { mode, phase }) || [];
+  const rects = DataManager.getData('rects', { mode, phase }) || [];
   updateSimulationRects(rects);
 }
 


### PR DESCRIPTION
## Summary
- create `physics` module to group force logic
- expose new `DataManager` in simulation data
- consolidate simulation UI exports
- update services and components to use new managers

## Testing
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_b_68535eeb2634832aadffb91d12a2ea58