### PR TITLE
Fix hotkey initialization

### DIFF
--- a/src/js/ui/components/hotkey-buttons.js
+++ b/src/js/ui/components/hotkey-buttons.js
@@ -12,8 +12,10 @@ export function initHotkeyButtons() {
   hotkeyMenuToggle.onclick   = e => {
     toggleHotkeyMenu();
   }
+  const options              = window.spwashi.keystrokeOptions || [];
+  if (!options.length) return;
   const optionList           = keystrokeOptions.appendChild(document.createElement('UL'));
-  window.spwashi.keystrokeOptions
+  options
         .filter(option => option.revealOrder <= window.spwashi.keystrokeRevealOrder)
         .forEach(({shortcut, categories = [], title, callback, shortcutName}) => {
           const handler = () => {

--- a/src/js/ui/hotkeys/_.js
+++ b/src/js/ui/hotkeys/_.js
@@ -9,6 +9,7 @@ function initKeystrokeHandlers(options) {
 
 export function initKeystrokes() {
   window.spwashi.keystrokeRevealOrder = window.spwashi.keystrokeRevealOrder || 0;
+  window.spwashi.keystrokeOptions = window.spwashi.keystrokeOptions || [];
 
   function plainKeyHandler(key, e) {
     const shortKeyEntries = window.spwashi.modeOrder.map((reflex, i) => [i + 1, () => setDocumentMode(reflex, true, true)]);

--- a/src/styles/scss/form-factors/desktop.scss
+++ b/src/styles/scss/form-factors/desktop.scss
@@ -1,7 +1,4 @@
 @media (min-width: 901px) {
-    #main-log {
-        display: flex;
-    }
     #mainmenu-shortcuts button {
         width: 5rem;
         height: 5rem;


### PR DESCRIPTION
## Summary
- ensure hotkey buttons don't error if key options aren't loaded
- initialize empty key options list
- only show main log in debug mode

## Testing
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_b_685371ee15bc832a9bcb716874bede72