### PR TITLE
Add debug logger and event tools

### DIFF
--- a/src/js/bootstrap/parameters/options/debug.js
+++ b/src/js/bootstrap/parameters/options/debug.js
@@ -1,7 +1,11 @@
+function isLocalhost() {
+  return /^(localhost|127\.|0\.0\.0\.0)/.test(window.location.hostname);
+}
+
 export function debug(searchParameters) {
-  if (searchParameters.has('debug')) {
+  if (searchParameters.has('debug') || isLocalhost()) {
     window.spwashi.parameters.debug = true;
-    document.body.dataset.debug     = 'debug'
+    document.body.dataset.debug = 'debug';
   }
   return ['debug', window.spwashi.parameters.debug];
 }

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -1,5 +1,7 @@
 import { addInitSteps, runInitPipeline } from "./bootstrap/init-pipeline";
 import { defaultInitSteps } from "./bootstrap/init-steps";
+import { expectEvent } from "./services/events.js";
+import { debug } from "./services/logger.js";
 
 const versions = {
   'v0.0.1': {
@@ -34,10 +36,11 @@ export async function app() {
 
   await runInitPipeline();
 
-  return Promise.all([serviceWorkerRegistered])
+  const readyPromise = expectEvent(document, 'simulation-ready', 5000)
+    .catch(() => {});
+
+  return Promise.all([serviceWorkerRegistered, readyPromise])
     .then(() => {
-      setTimeout(() => {
-        console.log('app is ready');
-      }, 1000);
+      debug('app is ready');
     });
 }

--- a/src/js/services/events.js
+++ b/src/js/services/events.js
@@ -1,0 +1,29 @@
+import { warn, debug } from './logger.js';
+
+/**
+ * Wait for a specific event on a target element. If the event does not
+ * fire within the given timeout, a warning is logged.
+ * @param {EventTarget} target - The event target to listen on
+ * @param {string} eventName - The name of the event to wait for
+ * @param {number} [timeout] - Optional timeout in milliseconds
+ * @returns {Promise<Event>} Resolves with the event when it fires
+ */
+export function expectEvent(target, eventName, timeout) {
+  return new Promise((resolve, reject) => {
+    const handler = (e) => {
+      clearTimeout(timer);
+      debug(`[event] ${eventName} fired`);
+      target.removeEventListener(eventName, handler);
+      resolve(e);
+    };
+    target.addEventListener(eventName, handler, { once: true });
+    let timer;
+    if (timeout) {
+      timer = setTimeout(() => {
+        warn(`[event] ${eventName} timed out after ${timeout}ms`);
+        target.removeEventListener(eventName, handler);
+        reject(new Error(`${eventName} timed out`));
+      }, timeout);
+    }
+  });
+}

--- a/src/js/services/logger.js
+++ b/src/js/services/logger.js
@@ -1,0 +1,25 @@
+export function isLocalhost() {
+  return /^(localhost|127\.|0\.0\.0\.0)/.test(window.location.hostname);
+}
+
+export function isDebug() {
+  return !!(window.spwashi?.parameters?.debug || isLocalhost());
+}
+
+export function debug(msg, ...args) {
+  if (isDebug()) {
+    console.debug(msg, ...args);
+  }
+}
+
+export function info(msg, ...args) {
+  console.info(msg, ...args);
+}
+
+export function warn(msg, ...args) {
+  console.warn(msg, ...args);
+}
+
+export function error(msg, ...args) {
+  console.error(msg, ...args);
+}

--- a/src/js/services/simulation/index.js
+++ b/src/js/services/simulation/index.js
@@ -5,6 +5,7 @@ import { getDefaultRects } from '../../simulation/rects/data/default';
 import { initSvgProperties, getSimulationElements } from '../../simulation/basic';
 import DataManager from '../../simulation/data';
 import { getCurrentQuery } from '../query-state';
+import { debug } from '../logger.js';
 
 function initNodes() {
   window.spwashi.clearCachedNodes = () => {
@@ -13,6 +14,7 @@ function initNodes() {
   window.spwashi.getNodeImageHref = getNodeImageHref;
   window.spwashi.getNode = NODE_MANAGER.getNode;
   window.spwashi.nodes = [];
+  debug('[sim] init nodes');
   const { mode, phase } = getCurrentQuery();
   const aggregator = window.spwashi.parameters.dataAggregator || 'array';
   const slice = DataManager.registerSlice('nodes', {
@@ -26,6 +28,7 @@ function initNodes() {
 
 function initEdges() {
   window.spwashi.links = [];
+  debug('[sim] init edges');
   const { mode, phase } = getCurrentQuery();
   const aggregator = window.spwashi.parameters.dataAggregator || 'array';
   const slice = DataManager.registerSlice('links', {
@@ -39,6 +42,7 @@ function initEdges() {
 
 function initRects() {
   window.spwashi.rects = getDefaultRects();
+  debug('[sim] init rects');
   const { mode, phase } = getCurrentQuery();
   const aggregator = window.spwashi.parameters.dataAggregator || 'array';
   const slice = DataManager.registerSlice('rects', {
@@ -56,9 +60,13 @@ export function initSimulationRoot() {
   const { svg } = getSimulationElements();
   initSvgProperties(svg);
 
+  debug('[sim] initializing simulation root');
+
   initNodes();
   initEdges();
   initRects();
+
+  debug('[sim] registered data slices');
 
   window.spwashi.simulation = forceSimulation();
   const { mode, phase } = getCurrentQuery();
@@ -71,6 +79,7 @@ export function initSimulationRoot() {
 
   import('../../simulation/reinit').then(({ reinit }) => {
     window.spwashi.reinit = reinit;
+    debug('[sim] calling reinit');
     reinit();
   });
 }

--- a/src/js/simulation/reinit.js
+++ b/src/js/simulation/reinit.js
@@ -1,5 +1,6 @@
 import { initializeForces } from "./physics";
 import { initSvgProperties, getSimulationElements } from "./basic";
+import { debug } from "../services/logger.js";
 import {
   updateSimulationLinks,
   updateSimulationNodes,
@@ -22,15 +23,21 @@ export async function reinit() {
     const simulationElements = getSimulationElements();
     initSvgProperties(simulationElements.svg);
 
+    debug('[sim] reinitializing simulation');
+
     window.spwashi.counter = 0;
 
     // Dynamically load node, edge, and rect managers
     const { NODE_MANAGER, EDGE_MANAGER, RECT_MANAGER } = await loadManagers();
 
+    debug('[sim] managers loaded');
+
     // Initialize nodes, edges, and rects
     const nodes = NODE_MANAGER.initNodes(window.spwashi.nodes);
     const edges = EDGE_MANAGER.initLinks(nodes);
     const rects = RECT_MANAGER.initRects(window.spwashi.rects);
+
+    debug(`[sim] nodes:${nodes.length} edges:${edges.length} rects:${rects.length}`);
 
     const simulation = window.spwashi.simulation;
     simulation.nodes(nodes);
@@ -65,6 +72,9 @@ export async function reinit() {
       return;
     }
     outputElement.innerHTML = JSON.stringify(window.spwashi.parameters, null, 2);
+
+    debug('[sim] reinit complete');
+    document.dispatchEvent(new CustomEvent('simulation-ready'));
 
   } catch (error) {
     console.error('Error during reinit:', error);

--- a/src/js/ui/component-registry.js
+++ b/src/js/ui/component-registry.js
@@ -1,3 +1,5 @@
+import { debug } from '../services/logger.js';
+
 export const componentRegistry = new Map();
 
 export function registerComponent(name, lifecycle) {
@@ -5,12 +7,15 @@ export function registerComponent(name, lifecycle) {
     throw new Error('registerComponent requires a name and an init function');
   }
   componentRegistry.set(name, lifecycle);
+  debug(`[ui] registered component: ${name}`);
 }
 
 export function initRegisteredComponents() {
   for (const [name, { init }] of componentRegistry) {
     try {
+      debug(`[ui] init component: ${name}`);
       init();
+      debug(`[ui] init complete: ${name}`);
     } catch (err) {
       console.error(`Failed to init component: ${name}`, err);
     }
@@ -21,6 +26,7 @@ export function destroyRegisteredComponents() {
   for (const [name, { destroy }] of componentRegistry) {
     if (typeof destroy === 'function') {
       try {
+        debug(`[ui] destroy component: ${name}`);
         destroy();
       } catch (err) {
         console.error(`Failed to destroy component: ${name}`, err);


### PR DESCRIPTION
## Summary
- detect localhost for debug parameter
- introduce centralized logger and event expectation helper
- use logger in component registry and simulation modules
- emit `simulation-ready` event after reinit and wait for it in main

## Testing
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_b_68537518acf4832a947322d5d01316a3