### PR TITLE
Fix data slice lookup with slice names

### DIFF
--- a/src/js/services/simulation/index.js
+++ b/src/js/services/simulation/index.js
@@ -15,12 +15,13 @@ function initNodes() {
   window.spwashi.getNode = NODE_MANAGER.getNode;
   window.spwashi.nodes = [];
   debug('[sim] init nodes');
-  const { mode, phase } = getCurrentQuery();
+  const { mode, phase, slice: sliceName } = getCurrentQuery();
   const aggregator = window.spwashi.parameters.dataAggregator || 'array';
   const slice = DataManager.registerSlice('nodes', {
     initialData: window.spwashi.nodes,
     mode,
     phase,
+    sliceName,
     aggregator,
   });
   window.spwashi.nodesSlice = slice;
@@ -29,12 +30,13 @@ function initNodes() {
 function initEdges() {
   window.spwashi.links = [];
   debug('[sim] init edges');
-  const { mode, phase } = getCurrentQuery();
+  const { mode, phase, slice: sliceName } = getCurrentQuery();
   const aggregator = window.spwashi.parameters.dataAggregator || 'array';
   const slice = DataManager.registerSlice('links', {
     initialData: window.spwashi.links,
     mode,
     phase,
+    sliceName,
     aggregator,
   });
   window.spwashi.linksSlice = slice;
@@ -43,12 +45,13 @@ function initEdges() {
 function initRects() {
   window.spwashi.rects = getDefaultRects();
   debug('[sim] init rects');
-  const { mode, phase } = getCurrentQuery();
+  const { mode, phase, slice: sliceName } = getCurrentQuery();
   const aggregator = window.spwashi.parameters.dataAggregator || 'array';
   const slice = DataManager.registerSlice('rects', {
     initialData: window.spwashi.rects,
     mode,
     phase,
+    sliceName,
     aggregator,
   });
   window.spwashi.rectsSlice = slice;
@@ -69,11 +72,12 @@ export function initSimulationRoot() {
   debug('[sim] registered data slices');
 
   window.spwashi.simulation = forceSimulation();
-  const { mode, phase } = getCurrentQuery();
+  const { mode, phase, slice: sliceName } = getCurrentQuery();
   DataManager.registerSlice('simulation', {
     initialData: window.spwashi.simulation,
     mode,
     phase,
+    sliceName,
     aggregator: 'array',
   });
 

--- a/src/js/ui/components/simulation/links.js
+++ b/src/js/ui/components/simulation/links.js
@@ -6,15 +6,15 @@ import { getCurrentQuery } from '../../../services/query-state';
 
 export function updateSimulationLinks(links) {
   const { wrapper } = getSimulationElements();
-  const { mode, phase } = getCurrentQuery();
-  if (DataManager.isDisplayEnabled('links', { mode, phase })) {
+  const { mode, phase, slice: sliceName } = getCurrentQuery();
+  if (DataManager.isDisplayEnabled('links', { mode, phase, sliceName })) {
     EDGE_MANAGER.updateLinks(wrapper, links);
   }
 }
 
 export function initSimulationLinks() {
-  const { mode, phase } = getCurrentQuery();
-  const links = DataManager.getData('links', { mode, phase }) || [];
+  const { mode, phase, slice: sliceName } = getCurrentQuery();
+  const links = DataManager.getData('links', { mode, phase, sliceName }) || [];
   updateSimulationLinks(links);
 }
 

--- a/src/js/ui/components/simulation/nodes.js
+++ b/src/js/ui/components/simulation/nodes.js
@@ -6,15 +6,15 @@ import { getCurrentQuery } from '../../../services/query-state';
 
 export function updateSimulationNodes(nodes) {
   const { wrapper } = getSimulationElements();
-  const { mode, phase } = getCurrentQuery();
-  if (DataManager.isDisplayEnabled('nodes', { mode, phase })) {
+  const { mode, phase, slice: sliceName } = getCurrentQuery();
+  if (DataManager.isDisplayEnabled('nodes', { mode, phase, sliceName })) {
     NODE_MANAGER.updateNodes(wrapper, nodes);
   }
 }
 
 export function initSimulationNodes() {
-  const { mode, phase } = getCurrentQuery();
-  const nodes = DataManager.getData('nodes', { mode, phase }) || [];
+  const { mode, phase, slice: sliceName } = getCurrentQuery();
+  const nodes = DataManager.getData('nodes', { mode, phase, sliceName }) || [];
   updateSimulationNodes(nodes);
 }
 

--- a/src/js/ui/components/simulation/rects.js
+++ b/src/js/ui/components/simulation/rects.js
@@ -6,15 +6,15 @@ import { getCurrentQuery } from '../../../services/query-state';
 
 export function updateSimulationRects(rects) {
   const { wrapper } = getSimulationElements();
-  const { mode, phase } = getCurrentQuery();
-  if (DataManager.isDisplayEnabled('rects', { mode, phase })) {
+  const { mode, phase, slice: sliceName } = getCurrentQuery();
+  if (DataManager.isDisplayEnabled('rects', { mode, phase, sliceName })) {
     RECT_MANAGER.updateRects(wrapper, rects);
   }
 }
 
 export function initSimulationRects() {
-  const { mode, phase } = getCurrentQuery();
-  const rects = DataManager.getData('rects', { mode, phase }) || [];
+  const { mode, phase, slice: sliceName } = getCurrentQuery();
+  const rects = DataManager.getData('rects', { mode, phase, sliceName }) || [];
   updateSimulationRects(rects);
 }
 


### PR DESCRIPTION
## Summary
- include `sliceName` on simulation slices
- use sliceName when reading nodes/links/rects

## Testing
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_b_685378a344e8832a98abb5b9202b1596