### PR TITLE
Fix simulation slice lookup across phases

### DIFF
--- a/src/js/simulation/data/registry.js
+++ b/src/js/simulation/data/registry.js
@@ -17,7 +17,16 @@ export function registerSlice(key, { initialData = [], dataSlice, aggregator = '
 
 export function getSlice(key, { mode = 'default', phase = 'default', sliceName = '' } = {}) {
   const regKey = makeKey(key, mode, phase, sliceName);
-  return registry.get(regKey)?.slice;
+  if (registry.has(regKey)) {
+    return registry.get(regKey).slice;
+  }
+  for (const [k, { slice }] of registry.entries()) {
+    const [m, p, s, kKey] = k.split(':');
+    if (kKey === key && m === mode && s === sliceName) {
+      return slice;
+    }
+  }
+  return undefined;
 }
 
 export function getData(key, opts = {}) {
@@ -34,7 +43,16 @@ export function toggleDisplay(key, { mode = 'default', phase = 'default', sliceN
 
 export function isDisplayEnabled(key, { mode = 'default', phase = 'default', sliceName = '' } = {}) {
   const regKey = makeKey(key, mode, phase, sliceName);
-  return registry.get(regKey)?.display ?? false;
+  if (registry.has(regKey)) {
+    return registry.get(regKey).display ?? false;
+  }
+  for (const [k, entry] of registry.entries()) {
+    const [m, p, s, kKey] = k.split(':');
+    if (kKey === key && m === mode && s === sliceName) {
+      return entry.display;
+    }
+  }
+  return false;
 }
 
 export function clearData(key, opts = {}) {


### PR DESCRIPTION
## Summary
- fall back to any registered slice when lookup by phase fails

## Testing
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_b_68537ab6918c832a89792837dec93a27