### PR TITLE
Fix keystroke menu button contrast and svg color

### DIFF
--- a/src/styles/scss/core/root.scss
+++ b/src/styles/scss/core/root.scss
@@ -26,6 +26,8 @@
   --log-background: rgba(127, 137, 137, .9);
   --stream-container-background: #222222;
 
+  --simulation-background: #707070;
+
   --node-input-container-background: #222222;
   --show-keystroke-options-background: #222222;
   --keystroke-options-hover-background: #333333;

--- a/src/styles/scss/core/svg.scss
+++ b/src/styles/scss/core/svg.scss
@@ -2,6 +2,10 @@ svg {
   display: block;
   overflow: visible;
 }
+
+svg#simulation {
+  background: var(--simulation-background);
+}
 line {
   stroke: var(--link-stroke-color);
 }
@@ -10,7 +14,7 @@ text {
   font-family: monospace;
   white-space: pre;
   fill: black;
-  --text-color: white;
+  --text-color: #ccc;
 }
 circle {
   filter: drop-shadow(3px 3px 2px rgba(0, 0, 0, .7));

--- a/src/styles/scss/widgets/hotkey-menu.scss
+++ b/src/styles/scss/widgets/hotkey-menu.scss
@@ -37,8 +37,8 @@
     padding: .5rem;
     margin: 0;
     border: none;
-    background: none;
-    color: var(--mainmenu-text-color);
+    background: var(--button-background);
+    color: var(--button-text-color);
     outline: thin solid var(--standard-outline);
     cursor: pointer;
     font-weight: bold;


### PR DESCRIPTION
## Summary
- keep keystroke option buttons consistent with button variables
- give the simulation SVG a soft gray background
- use a light gray as the default text color inside SVGs
- expose `--simulation-background` variable

## Testing
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_b_68537d35d46c832ab0355338f1a80e9e