### PR TITLE
Fix simulation render initialization

### DIFF
--- a/src/js/simulation/reinit.js
+++ b/src/js/simulation/reinit.js
@@ -65,6 +65,9 @@ export async function reinit() {
     // Attach the ticker to the simulation's 'tick' event
     simulation.on('tick', window.spwashi.internalTicker);
 
+    // Kick off the first tick so that the SVG renders immediately
+    window.spwashi.tick();
+
     // Update the output element with current parameters
     const outputElement = document.querySelector('#output');
     if (!outputElement) {


### PR DESCRIPTION
## Summary
- trigger a tick right after attaching the simulation tick handler so the SVG updates immediately

## Testing
- `yarn build` *(fails: lockfile missing)*

------
https://chatgpt.com/codex/tasks/task_b_68537d1eb810832a91783324fe7df511