### PR TITLE
Add backtick hotkey for main menu toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,3 +73,10 @@ now recognizes `prefers-contrast` and `prefers-reduced-transparency`
 media queries to accommodate users that request extra contrast or minimal
 translucency.
 
+
+## Keyboard Shortcuts
+
+- Press the **backtick** (`\``) to toggle the main menu.
+- Press **1** through **9** to switch between the available input modes.
+- Stream modes are under development and currently disabled.
+

--- a/src/js/ui/hotkeys/_.js
+++ b/src/js/ui/hotkeys/_.js
@@ -1,6 +1,7 @@
 import {setDocumentMode}    from "../../modes/input";
 import { initHotkeyButtons } from "../components/hotkey-buttons";
 import {processPastedText}  from "./handlers/pasted-text";
+import {toggleMainMenu}    from "./handlers/toggle-main-menu";
 
 function initKeystrokeHandlers(options) {
   window.spwashi.keystrokeOptions = options;
@@ -16,6 +17,10 @@ export function initKeystrokes() {
     const shortKeys       = Object.fromEntries(shortKeyEntries);
 
     if (['INPUT', 'TEXTAREA'].includes(document.activeElement.tagName)) return;
+    if (key === '`') {
+      toggleMainMenu();
+      return;
+    }
     if (key === '/') {
       e.preventDefault();
       const h1 = document.querySelector('h1');


### PR DESCRIPTION
## Summary
- document keyboard shortcuts
- wire up a new backtick hotkey to show/hide the main menu

## Testing
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_b_6853809fad8c832ab5d8c52d348d6599