### PR TITLE
Refactor mode loading fallback

### DIFF
--- a/src/js/modes/stream/bane.js
+++ b/src/js/modes/stream/bane.js
@@ -1,7 +1,4 @@
 import { ConfigModeHandler } from './base.js';
 export class BaneModeHandler extends ConfigModeHandler {
   constructor(container) { super(container, 'bane'); }
-  fallback() {
-    return `<div class="bane-loading">Loading Bane...</div>`;
-  }
 }

--- a/src/js/modes/stream/base.js
+++ b/src/js/modes/stream/base.js
@@ -4,7 +4,9 @@ export class ModeHandler {
   }
 
   fallback() {
-    return `<div class="mode-loading">Loading...</div>`;
+    const mode = this.mode || this.container.currentMode || 'mode';
+    const label = mode.charAt(0).toUpperCase() + mode.slice(1);
+    return `<div class="${mode}-loading">Loading ${label}...</div>`;
   }
 
   setupDataManager() {

--- a/src/js/modes/stream/bone.js
+++ b/src/js/modes/stream/bone.js
@@ -1,7 +1,4 @@
 import { ConfigModeHandler } from './base.js';
 export class BoneModeHandler extends ConfigModeHandler {
   constructor(container) { super(container, 'bone'); }
-  fallback() {
-    return `<div class="bone-loading">Loading Bone...</div>`;
-  }
 }

--- a/src/js/modes/stream/bonk.js
+++ b/src/js/modes/stream/bonk.js
@@ -1,7 +1,4 @@
 import { ConfigModeHandler } from './base.js';
 export class BonkModeHandler extends ConfigModeHandler {
   constructor(container) { super(container, 'bonk'); }
-  fallback() {
-    return `<div class="bonk-loading">Loading Bonk...</div>`;
-  }
 }

--- a/src/js/modes/stream/boof.js
+++ b/src/js/modes/stream/boof.js
@@ -1,9 +1,6 @@
 import { ModeHandler } from './base.js';
 
 export class BoofModeHandler extends ModeHandler {
-  fallback() {
-    return `<div class="boof-loading">Loading Boof...</div>`;
-  }
   render() {
     return `
       <div class="input-wrapper">

--- a/src/js/modes/stream/boon.js
+++ b/src/js/modes/stream/boon.js
@@ -1,9 +1,6 @@
 import { ModeHandler } from './base.js';
 
 export class BoonModeHandler extends ModeHandler {
-  fallback() {
-    return `<div class="boon-loading">Loading Boons...</div>`;
-  }
   render() {
     const defaultValues = {
       name: 'Default Boon Name',

--- a/src/js/modes/stream/focal.js
+++ b/src/js/modes/stream/focal.js
@@ -2,9 +2,6 @@ import { ModeHandler } from './base.js';
 import { focalPoint, initFocalSquare } from '../focal-point.js';
 
 export class FocalModeHandler extends ModeHandler {
-  fallback() {
-    return `<div class="focal-loading">Loading Focal...</div>`;
-  }
   render() {
     return `
       <button class="focal-submit">Set Focal Point</button>

--- a/src/js/modes/stream/honk.js
+++ b/src/js/modes/stream/honk.js
@@ -1,7 +1,4 @@
 import { ConfigModeHandler } from './base.js';
 export class HonkModeHandler extends ConfigModeHandler {
   constructor(container) { super(container, 'honk'); }
-  fallback() {
-    return `<div class="honk-loading">Loading Honk...</div>`;
-  }
 }

--- a/src/js/modes/stream/lore.js
+++ b/src/js/modes/stream/lore.js
@@ -1,7 +1,4 @@
 import { ConfigModeHandler } from './base.js';
 export class LoreModeHandler extends ConfigModeHandler {
   constructor(container) { super(container, 'lore'); }
-  fallback() {
-    return `<div class="lore-loading">Loading Lore...</div>`;
-  }
 }

--- a/src/js/modes/stream/passive.js
+++ b/src/js/modes/stream/passive.js
@@ -1,9 +1,6 @@
 import { ModeHandler } from './base.js';
 
 export class PassiveModeHandler extends ModeHandler {
-  fallback() {
-    return `<div class="passive-loading">Loading Passive...</div>`;
-  }
   render() {
     return `<div class="passive-message">Passive mode active. Waiting for updates…</div>`;
   }


### PR DESCRIPTION
## Summary
- unify fallback loading view in base mode handler
- rely on base implementation across all mode files

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_685386b22444832a9e0355d6287dd4d3