### PR TITLE
Add ARIA docs and annotate markup

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ preferences for reduced motion and light or dark color schemes. Set
 `data-theme="high-contrast"` or `data-theme="dark"` on the `<body>`
 element to override the system preference.
 
+Additional ARIA guidance for the markup is available in
+[docs/aria.md](docs/aria.md), which now maps elements to their
+corresponding JavaScript modules.
+
 ## Responsive Design
 
 Viewport specific overrides live under `styles/scss/form-factors`.

--- a/docs/aria.md
+++ b/docs/aria.md
@@ -1,0 +1,42 @@
+# ARIA Roles and Labels
+
+This document lists the key interface elements with their associated ARIA attributes.
+The markup is annotated so assistive technologies and language models can
+understand the purpose of each feature.
+
+## Feature Overview
+
+- **Main Stream Container** (`#main-stream-container`)
+  - `role="region"`
+  - `aria-label="Live Stream"`
+  - Contains the `<spwashi-stream-container>` element (`role="feed"`).
+  - Implemented in `src/js/ui/components/stream-container.js`, which opens a WebSocket and dispatches mode handlers from `src/js/modes/stream`.
+- **Simulation SVG** (`#simulation`)
+  - `aria-label="Simulation"`
+  - Wraps dynamic nodes, edges and rectangles.
+  - Updated by the modules under `src/js/simulation`, such as `basic.js`, `forces.js`, and `events.js`.
+- **Event Log** (`#main-log`)
+  - `role="log"`
+  - `aria-live="polite"`
+  - Displays streamed updates.
+  - Entries are pushed through the `logMainEvent()` helper in `src/js/simulation/nodes/ui/circle.js`.
+- **Image Container** (`#main-image-container`)
+  - `aria-label="Image Viewer"`
+  - Filled by `src/js/ui/components/page-image.js` when a base64 image is provided.
+- **Focus Toggle** (`#focal-square`)
+  - `aria-label="Focus Target"`
+  - Controlled by `src/js/ui/components/focal-point.js` and can also be toggled with a hotkey defined in `src/js/ui/hotkeys/handlers/toggle-focal-point.js`.
+- **Mode Sections** (`#spw-mode-container`, `#story-mode-container`, etc.)
+  - Each section has `aria-label` describing the mode.
+  - Corresponding handlers live under `src/js/modes` and are bound when the UI initializes.
+- **Keyboard Shortcuts Menu** (`#mainmenu-shortcuts`)
+  - `aria-label="Keyboard Shortcuts"`
+  - Populated by `src/js/ui/components/hotkey-buttons.js`.
+- **Hotkey Menu Toggle** (`#hotkey-menu-toggle`)
+  - `aria-label="Toggle Hotkey Menu"`
+  - Toggles interface depth via `src/js/ui/hotkeys/handlers/toggle-hotkey-menu.js`.
+- **Hotkey Options** (`#hotkey-container`)
+  - `aria-label="Hotkey Options"`
+  - Contains configurable shortcut buttons rendered by `hotkey-buttons`.
+
+These attributes clarify the purpose of the markup and show where each feature's interactive logic originates.

--- a/src/index.html
+++ b/src/index.html
@@ -15,14 +15,14 @@
 <body data-mode="nothing" data-interface-depth="standard" data-phase="initial">
 <button id="main-wonder-button">?</button>
 <h1>&lt;concept&gt;</h1>
-<section id="main-stream-container">
+<section id="main-stream-container" role="region" aria-label="Live Stream">
     <script src="https://unpkg.com/htmx.org@1.9.2"></script>
-    <spwashi-stream-container></spwashi-stream-container>
+    <spwashi-stream-container role="feed"></spwashi-stream-container>
 </section>
 <a id="title-md5"></a>
 <main>
     <div id="content">
-        <svg id="simulation">
+<svg id="simulation" aria-label="Simulation">
             <g class="simulation-content">
                 <g class="rects"></g>
                 <g class="edges"></g>
@@ -31,13 +31,13 @@
         </svg>
     </div>
 </main>
-<aside id="main-log">
+<aside id="main-log" role="log" aria-live="polite" aria-label="Event Log">
     <ul class="events-log"></ul>
 </aside>
-<section id="main-image-container"></section>
-<button id="focal-square" data-focal-status="inactive"></button>
-<aside id="mode-container">
-    <section id="spw-mode-container">
+<section id="main-image-container" aria-label="Image Viewer"></section>
+<button id="focal-square" data-focal-status="inactive" aria-label="Focus Target"></button>
+<aside id="mode-container" aria-label="Mode Controls">
+    <section id="spw-mode-container" aria-label="SPW Mode">
         <div id="spw-container">
             <label>
                 <span>input</span>
@@ -46,18 +46,18 @@
             <button id="parse-spw">parse</button>
         </div>
     </section>
-    <section id="story-mode-container">
+    <section id="story-mode-container" aria-label="Story Mode">
         <div class="button-container"></div>
     </section>
-    <section id="map-mode-container">
+    <section id="map-mode-container" aria-label="Map Mode">
         <div id="node-mapper" class="code-editor"></div>
         <button id="submit-node-mapper">submit</button>
     </section>
-    <section id="filter-mode-container">
+    <section id="filter-mode-container" aria-label="Filter Mode">
         <div id="node-filter" class="code-editor"></div>
         <button id="submit-node-filter">submit</button>
     </section>
-    <section id="querymod-mode-container">
+    <section id="querymod-mode-container" aria-label="Query Mode">
         <div id="query-parameters">
             <label>
                 <span>Query Parameters</span>
@@ -66,7 +66,7 @@
             <button class="go">go</button>
         </div>
     </section>
-    <section id="node-mode-container">
+    <section id="node-mode-container" aria-label="Node Mode">
         <div id="node-input-container">
             <label><span>Nodes Input</span><input id="nodes-input"/></label>
             <div class="button-container">
@@ -100,7 +100,7 @@
             </section>
         </div>
     </section>
-    <section id="color-mode-container">
+    <section id="color-mode-container" aria-label="Color Mode">
         <section id="colors">
             <button data-dataindex="spwashi-datum-0" class="color cls-0"></button>
             <button data-dataindex="spwashi-datum-1" class="color cls-1"></button>
@@ -117,20 +117,20 @@
             <button data-dataindex="spwashi-datum-12" class="color cls-12"></button>
         </section>
     </section>
-    <section id="reflex-mode-container">
+    <section id="reflex-mode-container" aria-label="Reflex Mode">
         <section id="reflexes"></section>
     </section>
-    <section id="debug-mode-container">
+    <section id="debug-mode-container" aria-label="Debug Mode">
         <section>
             <output id="output"></output>
         </section>
     </section>
 </aside>
-<section id="mainmenu-shortcuts">
+<section id="mainmenu-shortcuts" aria-label="Keyboard Shortcuts">
     <ol></ol>
 </section>
-<button id="hotkey-menu-toggle">[...]</button>
-<section id="hotkey-container" data-interface-element="hotkey-menu">
+<button id="hotkey-menu-toggle" aria-label="Toggle Hotkey Menu">[...]</button>
+<section id="hotkey-container" data-interface-element="hotkey-menu" aria-label="Hotkey Options">
     <section id="keystroke-options"></section>
 </section>
 </body>


### PR DESCRIPTION
## Summary
- document key ARIA roles
- reference the ARIA notes from the README
- add ARIA labels to index markup for each feature
- expand the ARIA guide with descriptions of which JS modules power each element

## Testing
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_b_68538ca5f064832aab9b1eebd57bd59b