### PR TITLE
Fix simulation node rendering

### DIFF
--- a/src/js/services/simulation/index.js
+++ b/src/js/services/simulation/index.js
@@ -1,10 +1,10 @@
-import { NODE_MANAGER } from '../../simulation/nodes/nodes';
+import { NODE_MANAGER } from '../../simulation/nodes/nodes.js';
 import { forceSimulation } from 'd3';
-import { getNodeImageHref } from '../../simulation/nodes/attr/href';
-import { getDefaultRects } from '../../simulation/rects/data/default';
-import { initSvgProperties, getSimulationElements } from '../../simulation/basic';
-import DataManager from '../../simulation/data';
-import { getCurrentQuery } from '../query-state';
+import { getNodeImageHref } from '../../simulation/nodes/attr/href.js';
+import { getDefaultRects } from '../../simulation/rects/data/default.js';
+import { initSvgProperties, getSimulationElements } from '../../simulation/basic.js';
+import DataManager from '../../simulation/data/index.js';
+import { getCurrentQuery } from '../query-state.js';
 import { debug } from '../logger.js';
 
 function initNodes() {
@@ -81,10 +81,13 @@ export function initSimulationRoot() {
     aggregator: 'array',
   });
 
-  import('../../simulation/reinit').then(({ reinit }) => {
+  import('../../simulation/reinit.js').then(({ reinit }) => {
     window.spwashi.reinit = reinit;
     debug('[sim] calling reinit');
-    reinit();
+    reinit().then(() => {
+      const count = document.querySelectorAll('g.nodes g.wrapper').length;
+      debug(`[sim] svg has ${count} node wrappers after reinit`);
+    });
   });
 }
 

--- a/src/js/simulation/nodes/nodes.js
+++ b/src/js/simulation/nodes/nodes.js
@@ -2,6 +2,7 @@
 
 import { processNode } from "./data/process.js";
 import { cacheNode, readNodePosition } from "./data/store.js";
+import { debug } from "../../services/logger.js";
 import { makeText, updateNodeTextSvg } from "./ui/text.js";
 import { makeRect } from "./ui/rect.js";
 import { makeCircle, updateCircle } from "./ui/circle.js";
@@ -52,12 +53,14 @@ function init(nodes, isMutable = false) {
  * @param {Array} nodes - The list of nodes to update.
  */
 function update(g, nodes) {
+  debug(`[nodes] update called with ${nodes.length} nodes`);
   const wrapperSelection = g
       .select('.nodes')
       .selectAll('g.wrapper')
       .data(nodes, d => d.id);
 
   wrapperSelection.join(enterNodes, updateNodes, removeNodes);
+  debug(`[nodes] selection after join: ${wrapperSelection.size()}`);
 }
 
 /**

--- a/src/js/simulation/reinit.js
+++ b/src/js/simulation/reinit.js
@@ -31,6 +31,12 @@ export async function reinit() {
     // Dynamically load node, edge, and rect managers
     const { NODE_MANAGER, EDGE_MANAGER, RECT_MANAGER } = await loadManagers();
 
+    // Generate a default set of nodes when none are present
+    if (window.spwashi.nodes.length === 0) {
+      const { generateNodes } = await import('./nodes/data/generate.js');
+      generateNodes(window.spwashi.parameters.nodes.count);
+    }
+
     debug('[sim] managers loaded');
 
     // Initialize nodes, edges, and rects

--- a/src/js/ui/components/simulation/nodes.js
+++ b/src/js/ui/components/simulation/nodes.js
@@ -3,18 +3,23 @@ import { getSimulationElements } from '../../../simulation/basic.js';
 import { registerComponent } from '../../component-registry.js';
 import DataManager from '../../../simulation/data/index.js';
 import { getCurrentQuery } from '../../../services/query-state.js';
+import { debug } from '../../../services/logger.js';
 
 export function updateSimulationNodes(nodes) {
   const { wrapper } = getSimulationElements();
   const { mode, phase, slice: sliceName } = getCurrentQuery();
   if (DataManager.isDisplayEnabled('nodes', { mode, phase, sliceName })) {
+    debug(`[sim-nodes] display enabled, rendering ${nodes.length} nodes`);
     NODE_MANAGER.updateNodes(wrapper, nodes);
+    const size = wrapper.select('.nodes').selectAll('g.wrapper').size();
+    debug(`[sim-nodes] DOM now has ${size} node wrappers`);
   }
 }
 
 export function initSimulationNodes() {
   const { mode, phase, slice: sliceName } = getCurrentQuery();
   const nodes = DataManager.getData('nodes', { mode, phase, sliceName }) || [];
+  debug(`[sim-nodes] init with ${nodes.length} nodes`);
   updateSimulationNodes(nodes);
 }
 

--- a/tests/reinit-generate.test.mjs
+++ b/tests/reinit-generate.test.mjs
@@ -1,0 +1,47 @@
+import { JSDOM } from 'jsdom';
+import { forceSimulation } from 'd3';
+import { initParameters } from '../src/js/bootstrap/parameters/init.js';
+
+const dom = new JSDOM(`<!DOCTYPE html><body><svg id="simulation"><g class="simulation-content"><g class="rects"></g><g class="edges"></g><g class="nodes"></g></g></svg><output id="output"></output></body>`);
+
+// expose globals for D3
+global.window = dom.window;
+global.document = dom.window.document;
+global.CustomEvent = dom.window.CustomEvent;
+global.navigator = { maxTouchPoints: 0 };
+
+envSetup();
+
+async function envSetup() {
+  window.spwashi = {
+    parameters: {},
+    nodes: [],
+    links: [],
+    rects: [],
+    callbacks: { acknowledgeLonging: () => {} },
+    simulation: forceSimulation(),
+    parameterKey: 'test'
+  };
+  initParameters();
+  window.spwashi.values = { fx: [], fy: [], r: [], text: { fontSize: [] } };
+  window.spwashi.getNodeImageHref = () => null;
+  window.spwashi.setItem = () => {};
+  window.spwashi.getItem = () => undefined;
+
+  const { initSimulationRoot } = await import('../src/js/services/simulation/index.js');
+  initSimulationRoot();
+}
+
+// Wait for simulation-ready event
+await new Promise(resolve => document.addEventListener('simulation-ready', resolve));
+
+const nodes = document.querySelectorAll('g.nodes g.wrapper');
+if (nodes.length === 0) {
+  throw new Error('expected nodes to be generated automatically');
+}
+if (window.spwashi.nodes.length === 0) {
+  throw new Error('window.spwashi.nodes not populated');
+}
+console.log(`generated ${nodes.length} node wrappers in SVG`);
+
+console.log('reinit generated default nodes');


### PR DESCRIPTION
## Summary
- ensure services/simulation uses explicit file extensions
- auto-generate default nodes during `reinit`
- log node updates and verify node wrappers in the SVG
- test that `reinit` populates nodes and renders wrappers

## Testing
- `npm test`
- `node --experimental-specifier-resolution=node tests/reinit-generate.test.mjs`


------
https://chatgpt.com/codex/tasks/task_b_68538cc3ca6c832a93ed0f2521f519b6