### PR TITLE
Add feature ID constants

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ yarn serve
 
 For details on how the initialization pipeline works, see [docs/init-pipeline.md](docs/init-pipeline.md).
 Metadata about registered data slices lives in [docs/api/data-meta.md](docs/api/data-meta.md).
+An overview of available features is provided in [docs/features.md](docs/features.md). You can import the `AppFeatures` object or individual constants like `INIT_PHASES` and `STREAM_MODES` from `src/js/app/features.js`.
 
 ### Routing and Query Parameters
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,0 +1,22 @@
+# Application Feature Reference
+
+This document maps major features of the Factshift web client to the modules implementing them. The `AppFeatures` object exported from `src/js/app/features.js` exposes the same information programmatically. Individual constants such as `INIT_PHASES` and `STREAM_MODES` can also be imported from that module for finer-grained dependencies.
+
+- **Initialization & Startup**
+  - Pipeline phases are defined in `src/js/bootstrap/init-pipeline.js` and enumerated by the `INIT_PHASES` constant.
+  - Routing and query helpers live under `src/js/services`.
+- **Real-time Streaming**
+  - Individual stream mode handlers are in `src/js/modes/stream` and listed in the `STREAM_MODES` array.
+  - `DataManager` in `src/js/services/data-manager.js` manages static or live sources.
+- **Simulation & Forces**
+  - Core D3 setup is located in `src/js/simulation/basic.js`.
+  - The force registry is implemented in `src/js/simulation/force-registry.js`.
+- **Input & Hotkeys**
+  - Keyboard mappings live in `src/js/config/hotkeys.js` with handlers under `src/js/ui/hotkeys`.
+- **UI & Accessibility**
+  - Responsive styles are in `src/styles/scss` and accessibility notes in `docs/aria.md`.
+- **PWA Features**
+  - The service worker script is distributed under `public/v0.0.2-alpha/service-worker.js`.
+  - PWA metadata is declared in `public/manifest.json`.
+- **Quality Assurance**
+  - QA notes and checklists live under `docs/qa`.

--- a/src/js/app/features.js
+++ b/src/js/app/features.js
@@ -1,0 +1,50 @@
+export const INIT_PHASES = {
+  BOOT: 'boot',
+  UI: 'ui',
+  REFRESH: 'refresh',
+  DEFERRED: 'deferred',
+};
+
+export const STREAM_MODES = [
+  'boon',
+  'bane',
+  'bone',
+  'bonk',
+  'honk',
+  'boof',
+  'lore',
+  'focal',
+  'passive',
+];
+
+export const AppFeatures = {
+  initialization: {
+    pipelinePhases: Object.values(INIT_PHASES),
+    router: 'services/router.js',
+    queryState: 'services/query-state.js',
+  },
+  streaming: {
+    modes: STREAM_MODES,
+    dataManager: 'services/data-manager.js',
+  },
+  simulation: {
+    modules: ['simulation/basic.js'],
+    forceRegistry: 'simulation/force-registry.js',
+  },
+  input: {
+    hotkeys: 'ui/hotkeys',
+  },
+  ui: {
+    responsiveScss: 'styles/scss',
+    accessibilityDocs: 'docs/aria.md',
+  },
+  pwa: {
+    serviceWorker: 'public/v0.0.2-alpha/service-worker.js',
+    manifest: 'public/manifest.json',
+  },
+  qa: {
+    docs: 'docs/qa',
+  },
+};
+
+export default AppFeatures;

--- a/src/js/app/index.js
+++ b/src/js/app/index.js
@@ -4,3 +4,4 @@ export { QueryParams } from '../services/query-params';
 export { default as QueryState, getCurrentQuery, getCurrentStatus } from '../services/query-state';
 export { default as DataManager } from '../simulation/data';
 export { initSimulationRoot } from '../services/simulation';
+export { default as AppFeatures, INIT_PHASES, STREAM_MODES } from './features.js';

--- a/src/js/bootstrap/init-pipeline.js
+++ b/src/js/bootstrap/init-pipeline.js
@@ -1,9 +1,6 @@
-export const InitPhase = {
-  BOOT: 'boot',
-  UI: 'ui',
-  REFRESH: 'refresh',
-  DEFERRED: 'deferred',
-};
+import { INIT_PHASES } from '../app/features.js';
+
+export const InitPhase = INIT_PHASES;
 
 const initSteps = [];
 const map = new Map();

--- a/src/js/ui/components/stream-container.js
+++ b/src/js/ui/components/stream-container.js
@@ -4,6 +4,7 @@ import { NODE_MANAGER } from '../../simulation/nodes/nodes';
 import { DataManager } from '../../services/data-manager.js';
 import { MODE_DOCS } from '../config/mode-docs.js';
 import { registerComponent } from '../component-registry.js';
+import { STREAM_MODES } from '../../app/features.js';
 import { BoofModeHandler } from '../../modes/stream/boof.js';
 import { BoonModeHandler } from '../../modes/stream/boon.js';
 import { BaneModeHandler } from '../../modes/stream/bane.js';
@@ -41,7 +42,7 @@ const modeConfig = {
 class SpwashiStreamContainer extends HTMLElement {
   constructor() {
     super();
-    this.currentMode = 'boon';
+    this.currentMode = STREAM_MODES[0];
     this.loading = true;
     this.error = null;
     this.initDataManager();
@@ -112,7 +113,7 @@ class SpwashiStreamContainer extends HTMLElement {
    * Returns the HTML template for the component.
    */
   getTemplateHtml() {
-    const modes = ['boon', 'bane', 'bone', 'bonk', 'honk', 'boof', 'lore', 'focal', 'passive'];
+    const modes = STREAM_MODES;
     const optionsHtml = modes
         .map(
             (mode) =>


### PR DESCRIPTION
## Summary
- export `INIT_PHASES` and `STREAM_MODES`
- re-use constants in initialization pipeline and stream container
- document named exports for feature metadata

## Testing
- `yarn test` *(fails: package missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_b_68538fa819fc832a978e327f3c4a5334