### PR TITLE
Refactor storage access

### DIFF
--- a/src/js/bootstrap/parameters/options/reset.js
+++ b/src/js/bootstrap/parameters/options/reset.js
@@ -1,6 +1,8 @@
+import { clearAll } from '../../../services/storage.js';
+
 export function reset(searchParameters) {
   if (searchParameters.has('reset')) {
-    window.localStorage.clear();
+    clearAll();
   }
-  return ['reset', false]
+  return ['reset', false];
 }

--- a/src/js/bootstrap/root.js
+++ b/src/js/bootstrap/root.js
@@ -1,10 +1,11 @@
 import { initSimulationRoot } from "../services/simulation";
-import {initCallbacks}      from "./callbacks/initCallbacks";
-import {initListeners}      from "./listeners/initListeners";
-import {pushHelpTopics}     from "../modes/input/spw/commands/help";
-import {setDocumentMode}    from "../modes/input";
-import {processSpwInput}    from "../modes/input/spw/process-spw-input";
-import { loadCssVars }      from "../services/style-state";
+import { initCallbacks } from "./callbacks/initCallbacks";
+import { initListeners } from "./listeners/initListeners";
+import { pushHelpTopics } from "../modes/input/spw/commands/help";
+import { setDocumentMode } from "../modes/input";
+import { processSpwInput } from "../modes/input/spw/process-spw-input";
+import { loadCssVars } from "../services/style-state";
+import * as storage from "../services/storage.js";
 
 export function initRoot() {
   initSimulationRoot();
@@ -71,24 +72,6 @@ export function initRoot() {
 
 function initRootSession() {
   window.spwashi.__session = window.spwashi.__session || {i: 0};
-  window.spwashi.setItem   = (key, item, category = null) => {
-    try {
-      window.localStorage.setItem(getItemKey(key, category), JSON.stringify(item || null));
-    } catch (e) {
-      console.error({e, item});
-    }
-  }
-  window.spwashi.getItem   = (key, category = null) => {
-    const out = window.localStorage.getItem(getItemKey(key, category))
-    if (out) return JSON.parse(out || '{}')
-    return undefined;
-  }
-}
-
-function getItemKey(key, category = null) {
-  if (!category) {
-    category = window.spwashi.parameterKey
-  }
-
-  return category + '@' + key;
+  window.spwashi.setItem = storage.setItem;
+  window.spwashi.getItem = storage.getItem;
 }

--- a/src/js/modes/stream/base.js
+++ b/src/js/modes/stream/base.js
@@ -1,3 +1,5 @@
+import * as storage from '../../services/storage.js';
+
 export class ModeHandler {
   constructor(container) {
     this.container = container;
@@ -76,7 +78,7 @@ export class ConfigModeHandler extends ModeHandler {
 
   loadSettings() {
     try {
-      return JSON.parse(localStorage.getItem(this.storageKey)) || this.getDefaults();
+      return storage.getItem(this.storageKey) || this.getDefaults();
     } catch {
       return this.getDefaults();
     }
@@ -129,7 +131,7 @@ export class ConfigModeHandler extends ModeHandler {
 
   saveSettings() {
     const data = this.getSettings();
-    localStorage.setItem(this.storageKey, JSON.stringify(data));
+    storage.setItem(this.storageKey, data);
     this.container.displayMessage(`${this.mode} settings saved locally`, 'success');
   }
 

--- a/src/js/services/cache.js
+++ b/src/js/services/cache.js
@@ -1,4 +1,5 @@
 // services/cache.js
+import * as storage from './storage.js';
 
 export const UI_CACHE_CATEGORY = 'ui.cache';
 
@@ -7,8 +8,8 @@ export const UI_CACHE_CATEGORY = 'ui.cache';
  * Logs the action when debug mode is enabled.
  */
 export function cacheItem(key, value, category = UI_CACHE_CATEGORY) {
-  if (window.spwashi && window.spwashi.setItem) {
-    window.spwashi.setItem(key, value, category);
+  if (window.spwashi) {
+    storage.setItem(key, value, category);
     if (window.spwashi.parameters?.debug) {
       console.log(`[cache] set ${key} ->`, value);
     }
@@ -22,8 +23,8 @@ export function cacheItem(key, value, category = UI_CACHE_CATEGORY) {
  * Logs the result when debug mode is enabled.
  */
 export function loadCachedItem(key, category = UI_CACHE_CATEGORY) {
-  if (!window.spwashi || !window.spwashi.getItem) return undefined;
-  const value = window.spwashi.getItem(key, category);
+  if (!window.spwashi) return undefined;
+  const value = storage.getItem(key, category);
   if (window.spwashi.parameters?.debug) {
     console.log(`[cache] load ${key} ->`, value);
   }

--- a/src/js/services/storage.js
+++ b/src/js/services/storage.js
@@ -1,0 +1,25 @@
+export function getItemKey(key, category = null, parameterKey = window.spwashi?.parameterKey) {
+  if (!category) {
+    category = parameterKey;
+  }
+  return `${category}@${key}`;
+}
+
+export function setItem(key, item, category = null) {
+  try {
+    window.localStorage.setItem(getItemKey(key, category), JSON.stringify(item ?? null));
+  } catch (e) {
+    console.error({ e, item });
+  }
+}
+
+export function getItem(key, category = null) {
+  const out = window.localStorage.getItem(getItemKey(key, category));
+  if (out) return JSON.parse(out || '{}');
+  return undefined;
+}
+
+export function clearAll() {
+  window.localStorage.clear();
+}
+

--- a/src/js/ui/hotkeys/handlers/reset-interface.js
+++ b/src/js/ui/hotkeys/handlers/reset-interface.js
@@ -1,4 +1,5 @@
-import {getNextUrlSearchParams} from "../../../util/next-url";
+import { getNextUrlSearchParams } from "../../../util/next-url";
+import { clearAll } from "../../../services/storage.js";
 
 function getNextHref(nextParams) {
   const href = window.location.href.split('?')[0];
@@ -6,7 +7,7 @@ function getNextHref(nextParams) {
 }
 
 export function resetInterface() {
-  window.localStorage.clear();
+  clearAll();
   const nextParams     = getNextUrlSearchParams();
   window.location.href = getNextHref(nextParams);
 }


### PR DESCRIPTION
## Summary
- centralize localStorage helpers in `storage.js`
- use the new helpers in bootstrap and cache modules
- update other modules to call the storage service

## Testing
- `npm test`
- ❌ `yarn test` *(fails: package not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_b_68538fe8ce70832aba54d0358664b5dc