### PR TITLE
Add query param docs

### DIFF
--- a/docs/aria.md
+++ b/docs/aria.md
@@ -38,5 +38,8 @@ understand the purpose of each feature.
 - **Hotkey Options** (`#hotkey-container`)
   - `aria-label="Hotkey Options"`
   - Contains configurable shortcut buttons rendered by `hotkey-buttons`.
+- **Query Parameter Documentation** (`#query-param-docs`)
+  - `aria-label="Query Parameter Documentation"`
+  - Populated at runtime by `src/js/ui/components/query-param-docs.js`.
 
 These attributes clarify the purpose of the markup and show where each feature's interactive logic originates.

--- a/src/index.html
+++ b/src/index.html
@@ -133,4 +133,8 @@
 <section id="hotkey-container" data-interface-element="hotkey-menu" aria-label="Hotkey Options">
     <section id="keystroke-options"></section>
 </section>
+<section id="query-param-docs" data-interface-element="main-menu" aria-label="Query Parameter Documentation">
+    <h2>Query Parameters</h2>
+    <ul></ul>
+</section>
 </body>

--- a/src/js/bootstrap/ui.js
+++ b/src/js/bootstrap/ui.js
@@ -6,6 +6,7 @@ import {initializeModeSelection}           from "../modes/input";
 import {initializeDataindexMode}           from "../modes/input/dataindex/mode-dataindex";
 import {initKeystrokes}                    from "../ui/hotkeys/_";
 import {initializeSpwParseField}           from "../modes/input/spw/mode-spw";
+import '../ui/components/query-param-docs.js';
 
 
 export function initUi(mode) {

--- a/src/js/ui/components/query-param-docs.js
+++ b/src/js/ui/components/query-param-docs.js
@@ -1,0 +1,29 @@
+import { registerComponent } from "../component-registry";
+import { parameterList } from "../../bootstrap/parameters/_";
+import { registeredParamNames } from "../../services/query-params";
+
+export function initQueryParamDocs() {
+  const container = document.querySelector('#query-param-docs');
+  if (!container) {
+    window.spwashi?.callbacks?.acknowledgeLonging?.('wondering about query param docs container');
+    return;
+  }
+  const list = container.querySelector('ul') || container.appendChild(document.createElement('ul'));
+  list.innerHTML = '';
+
+  const names = new Set();
+  parameterList.forEach(fn => {
+    if (typeof fn === 'function' && fn.name) {
+      names.add(fn.name);
+    }
+  });
+  registeredParamNames().forEach(name => names.add(name));
+
+  [...names].sort().forEach(name => {
+    const li = document.createElement('li');
+    li.innerHTML = `<kbd>?${name}</kbd>`;
+    list.appendChild(li);
+  });
+}
+
+registerComponent('query-param-docs', { init: initQueryParamDocs });


### PR DESCRIPTION
## Summary
- show list of query parameters in the main menu
- auto-populate list from JavaScript to keep docs in sync
- document new ARIA section

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_b_68539de8c824832aa06d6c4713aa844e