### PR TITLE
Improve reflex menu layout

### DIFF
--- a/src/styles/scss/form-factors/mobile.scss
+++ b/src/styles/scss/form-factors/mobile.scss
@@ -16,6 +16,9 @@
     #mainmenu-shortcuts li:before {
         content: none;
     }
+    #reflexes {
+        grid-template-columns: 1fr;
+    }
     #reflexes button {
         text-align: center;
         width: 4rem;

--- a/src/styles/scss/form-factors/tablet.scss
+++ b/src/styles/scss/form-factors/tablet.scss
@@ -6,6 +6,9 @@
         width: 4rem;
         height: 4rem;
     }
+    #reflexes {
+        grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr));
+    }
     #reflexes button {
         width: 5rem;
         height: 5rem;

--- a/src/styles/scss/modes/reflex-mode.scss
+++ b/src/styles/scss/modes/reflex-mode.scss
@@ -4,11 +4,12 @@
 #reflexes {
   margin: 1rem;
   border: thin solid var(--standard-outline);
-  display: flex;
-  flex-direction: column-reverse;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr));
+  gap: 1rem;
   .card-body {
     display: flex;
-    flex-direction: row;
+    flex-wrap: wrap;
     justify-content: center;
     align-items: center;
   }


### PR DESCRIPTION
## Summary
- restructure reflex menu styles using CSS grid
- adjust mobile and tablet layouts

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_b_68539eb1efd8832a9e3c8614bac486a0