### PR TITLE
Add stream mode selection menu

### DIFF
--- a/docs/websocket-notes.md
+++ b/docs/websocket-notes.md
@@ -6,6 +6,8 @@ Each mode's settings are stored locally in `localStorage` and may be transmitted
 
 The container uses a `DataManager` abstraction to source data either from static arrays or from a live WebSocket feed. Extend `modeConfig` in `stream-container.js` to point a mode at a live URL when the backend is available.
 
+Stream mode can now be changed from the **Debug Mode** menu via a dropdown labeled "Stream Mode". This dispatches a `stream-mode-change` event that updates the active handler.
+
 `LiveDataSource` now exposes a `close()` method. `ModeHandler.cleanup()` invokes this when present so switching modes or stream strategies cleans up the previous connection and callbacks.
 
 For detailed message formats see [Stream Mode Web APIs](api/modes.md).

--- a/src/js/ui/components/stream-container.js
+++ b/src/js/ui/components/stream-container.js
@@ -291,6 +291,12 @@ class SpwashiStreamContainer extends HTMLElement {
 
     this.streamStrategyChangeBound = this.handleStreamStrategyChange.bind(this);
     document.addEventListener('stream-strategy-change', this.streamStrategyChangeBound);
+
+    if (this.streamModeChangeBound) {
+      document.removeEventListener('stream-mode-change', this.streamModeChangeBound);
+    }
+    this.streamModeChangeBound = this.handleExternalModeChange.bind(this);
+    document.addEventListener('stream-mode-change', this.streamModeChangeBound);
   }
 
   /**
@@ -321,6 +327,15 @@ class SpwashiStreamContainer extends HTMLElement {
     }
     this.initDataManager();
     this.render();
+  }
+
+  handleExternalModeChange(e) {
+    const mode = e?.detail?.mode;
+    if (!mode || mode === this.currentMode) return;
+    if (this.modeSelector) {
+      this.modeSelector.value = mode;
+    }
+    this.handleModeChange();
   }
 
   /**

--- a/src/js/ui/components/stream-mode-menu.js
+++ b/src/js/ui/components/stream-mode-menu.js
@@ -1,0 +1,28 @@
+import { registerComponent } from "../component-registry";
+import { STREAM_MODES } from "../../app/features.js";
+
+export function initStreamModeMenu() {
+  const container = document.querySelector('#debug-mode-container');
+  if (!container) return;
+
+  const fieldset = document.createElement('fieldset');
+  const options = STREAM_MODES.map(m => `<option value="${m}">${m}</option>`).join('');
+  fieldset.innerHTML = `
+    <legend>Stream Mode</legend>
+    <label>
+      <select name="stream-mode">${options}</select>
+    </label>
+  `;
+  container.appendChild(fieldset);
+
+  const select = fieldset.querySelector('select[name="stream-mode"]');
+  select.value = window.spwashi.streamMode || STREAM_MODES[0];
+  select.addEventListener('change', () => {
+    window.spwashi.streamMode = select.value;
+    document.dispatchEvent(new CustomEvent('stream-mode-change', { detail: { mode: select.value } }));
+  });
+
+  window.spwashi.streamMode = select.value;
+}
+
+registerComponent('stream-mode-menu', { init: initStreamModeMenu });

--- a/src/styles/scss/main.scss
+++ b/src/styles/scss/main.scss
@@ -13,6 +13,7 @@
 @import "widgets/main-menu-toggle";
 @import "widgets/simulation-controls";
 @import "widgets/stream-config";
+@import "widgets/stream-mode-menu";
 
 /** vendor **/
 @import "vendor/ace-edit.scss";

--- a/src/styles/scss/widgets/stream-mode-menu.scss
+++ b/src/styles/scss/widgets/stream-mode-menu.scss
@@ -1,0 +1,8 @@
+#debug-mode-container fieldset {
+  border: 1px solid var(--accent-color-main);
+  padding: 0.5rem;
+  margin: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}


### PR DESCRIPTION
## Summary
- hook `stream-container` up to a new `stream-mode-change` event
- add Stream Mode dropdown component
- expose the dropdown styles and import them
- document how to use the new menu

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_b_68539f22643c832a944eeae9fc3ecc01